### PR TITLE
Experiment moving Filer provider calls to IndexedDB onto a Worker

### DIFF
--- a/src/bramble/client/HybridIndexedDBProvider.js
+++ b/src/bramble/client/HybridIndexedDBProvider.js
@@ -1,0 +1,59 @@
+/*global define, Worker */
+/*jslint bitwise: true */
+
+define([
+    "thirdparty/filer/dist/filer.min",
+    "bramble/client/RemoteIndexedDB"
+], function(Filer, RemoteIndexedDB) {
+    "use strict";
+
+    var NonWorkerIndexedDB = Filer.providers.IndexedDB;
+    var FILE_SYSTEM_NAME = "local";
+    var indexedDB = window.indexedDB       ||
+                    window.mozIndexedDB    ||
+                    window.webkitIndexedDB ||
+                    window.msIndexedDB;
+
+    /**
+     * Prefer to do run IndexedDB on a worker thread, but fall back to main thread.
+     */
+    function HybridIndexedDB(name) {
+        this.name = name || FILE_SYSTEM_NAME;
+        this._impl = null;
+    }
+    HybridIndexedDB.isSupported = function() {
+        // We'll either support it in the main thread or a worker
+        return !!indexedDB;
+    };
+
+    HybridIndexedDB.prototype.open = function(callback) {
+        var that = this;
+        var dbWorker = new Worker("/src/bramble/client/IndexedDBWorker.js");
+
+        function pickImplementation(e) {
+            dbWorker.removeEventListener("message", pickImplementation, false);
+            var workerSupportsIndexedDB = e.data.supported;
+
+            if(workerSupportsIndexedDB) {
+                that._impl = new RemoteIndexedDB(that.name, dbWorker);
+            } else {
+                that._impl = new NonWorkerIndexedDB(that.name);
+                dbWorker.terminate();
+                dbWorker = null;
+            }
+
+            that.impl.open(callback);
+        }
+        dbWorker.addEventListener("message", pickImplementation, false);
+        dbWorker.postMessage({type: "INIT", name: that.name});
+    };
+
+    HybridIndexedDB.prototype.getReadOnlyContext = function() {
+        return this._impl.getReadOnlyContext();
+    };
+    HybridIndexedDB.prototype.getReadWriteContext = function() {
+        return this._impl.getReadWriteContext();
+    };
+
+    return HybridIndexedDB;
+});

--- a/src/bramble/client/HybridIndexedDBProvider.js
+++ b/src/bramble/client/HybridIndexedDBProvider.js
@@ -7,7 +7,7 @@ define([
 ], function(Filer, RemoteIndexedDB) {
     "use strict";
 
-    var NonWorkerIndexedDB = Filer.providers.IndexedDB;
+    var NonWorkerIndexedDB = Filer.FileSystem.providers.IndexedDB;
     var FILE_SYSTEM_NAME = "local";
     var indexedDB = window.indexedDB       ||
                     window.mozIndexedDB    ||
@@ -42,7 +42,7 @@ define([
                 dbWorker = null;
             }
 
-            that.impl.open(callback);
+            that._impl.open(callback);
         }
         dbWorker.addEventListener("message", pickImplementation, false);
         dbWorker.postMessage({type: "INIT", name: that.name});

--- a/src/bramble/client/HybridIndexedDBProvider.js
+++ b/src/bramble/client/HybridIndexedDBProvider.js
@@ -7,7 +7,8 @@ define([
 ], function(Filer, RemoteIndexedDB) {
     "use strict";
 
-    var NonWorkerIndexedDB = Filer.FileSystem.providers.IndexedDB;
+    // NOTE: I'm using Fallback vs. IndexedDB to keep older Safari happy here.
+    var FallbackProvider = Filer.FileSystem.providers.Fallback;
     var FILE_SYSTEM_NAME = "local";
     var indexedDB = window.indexedDB       ||
                     window.mozIndexedDB    ||
@@ -37,7 +38,7 @@ define([
             if(workerSupportsIndexedDB) {
                 that._impl = new RemoteIndexedDB(that.name, dbWorker);
             } else {
-                that._impl = new NonWorkerIndexedDB(that.name);
+                that._impl = new FallbackProvider(that.name);
                 dbWorker.terminate();
                 dbWorker = null;
             }

--- a/src/bramble/client/IndexedDBWorker.js
+++ b/src/bramble/client/IndexedDBWorker.js
@@ -1,0 +1,170 @@
+/*global self */
+/*jslint bitwise: true */
+(function() {
+    "use strict";
+
+    var indexedDB = self.indexedDB       ||
+                    self.mozIndexedDB    ||
+                    self.webkitIndexedDB ||
+                    self.msIndexedDB;
+    var FILE_STORE_NAME = "files";
+    var provider;
+
+    function IndexedDBContext(db, mode) {
+        var transaction = db.transaction(FILE_STORE_NAME, mode);
+        this.objectStore = transaction.objectStore(FILE_STORE_NAME);
+    }
+
+    IndexedDBContext.prototype.clear = function(callback) {
+        try {
+            var request = this.objectStore.clear();
+            request.onsuccess = function(event) {
+                callback();
+            };
+            request.onerror = function(error) {
+                callback(error);
+            };
+        } catch(e) {
+            callback(e);
+        }
+    };
+
+    function _get(objectStore, key, callback) {
+        try {
+            var request = objectStore.get(key);
+            request.onsuccess = function onsuccess(event) {
+                var result = event.target.result;
+                callback(null, result);
+            };
+            request.onerror = function onerror(error) {
+                callback(error);
+            };
+        } catch(e) {
+            callback(e);
+        }
+    }
+    IndexedDBContext.prototype.getObject = function(key, callback) {
+        _get(this.objectStore, key, callback);
+    };
+    IndexedDBContext.prototype.getBuffer = function(key, callback) {
+        _get(this.objectStore, key, callback);
+    };
+
+    function _put(objectStore, key, value, callback) {  
+        try {
+            var request = objectStore.put(value, key);
+            request.onsuccess = function onsuccess(event) {
+                var result = event.target.result;
+                callback(null, result);
+            };
+            request.onerror = function onerror(error) {
+                callback(error);
+            };
+        } catch(e) {
+            callback(e);
+        }
+    }
+    IndexedDBContext.prototype.putObject = function(key, value, callback) {
+        _put(this.objectStore, key, value, callback);
+    };
+    IndexedDBContext.prototype.putBuffer = function(key, arrayBuffer, callback) {
+        _put(this.objectStore, key, arrayBuffer, callback);
+    };
+
+    IndexedDBContext.prototype.delete = function(key, callback) {
+        try {
+            var request = this.objectStore.delete(key);
+            request.onsuccess = function onsuccess(event) {
+                var result = event.target.result;
+                callback(null, result);
+            };
+            request.onerror = function(error) {
+                callback(error);
+            };
+        } catch(e) {
+            callback(e);
+        }
+    };
+
+
+    function IndexedDB(name) {
+        this.name = name;
+        this.db = null;
+    }
+    IndexedDB.isSupported = function() {
+        return !!indexedDB;
+    };
+
+    IndexedDB.prototype.open = function(callback) {
+        var that = this;
+
+        // Bail if we already have a db open
+        if(that.db) {
+            return callback();
+        }
+
+        // NOTE: we're not using versioned databases.
+        var openRequest = indexedDB.open(that.name);
+
+        // If the db doesn't exist, we'll create it
+        openRequest.onupgradeneeded = function onupgradeneeded(event) {
+            var db = event.target.result;
+
+            if(db.objectStoreNames.contains(FILE_STORE_NAME)) {
+                db.deleteObjectStore(FILE_STORE_NAME);
+            }
+            db.createObjectStore(FILE_STORE_NAME);
+        };
+
+        openRequest.onsuccess = function onsuccess(event) {
+            that.db = event.target.result;
+            callback();
+        };
+        openRequest.onerror = function onerror(error) {
+            callback(new Error('IndexedDB cannot be accessed. If private browsing is enabled, disable it.'));
+        };
+    };
+    IndexedDB.prototype.getReadOnlyContext = function() {
+        // Due to timing issues in Chrome with readwrite vs. readonly indexeddb transactions
+        // always use readwrite so we can make sure pending commits finish before callbacks.
+        // See https://github.com/js-platform/filer/issues/128
+        return new IndexedDBContext(this.db, "readwrite");
+    };
+    IndexedDB.prototype.getReadWriteContext = function() {
+        return new IndexedDBContext(this.db, "readwrite");
+    };
+
+
+    function execRemoteCall(options) {
+        var context = options.mode === "readonly" ?
+            provider.getReadOnlyContext() : provider.getReadWriteContext();
+
+        function callback(err, result) {
+            self.postMessage({
+                callback: options.callback,
+                result: [err, result]
+            });
+        }
+
+        var args = options.args.concat(callback);
+        context[options.method].apply(context, args);
+    }
+
+    function onMessage(e) {
+        var data = e.data;
+        var type = data.type;
+
+        if(type === "INIT") {
+            provider = new IndexedDB(data.name);
+            self.postMessage({supported: !!indexedDB});
+        } else if (type === "OPEN") {
+            provider.open(function(err) {
+                self.postMessage({type: "OPEN_CALLBACK", err: err});
+            });
+        } else {
+            execRemoteCall(data);
+        }
+    }
+
+    self.addEventListener("message", onMessage, false);
+}());

--- a/src/bramble/client/RemoteIndexedDB.js
+++ b/src/bramble/client/RemoteIndexedDB.js
@@ -1,0 +1,114 @@
+/*global define*/
+/*jslint bitwise: true */
+
+define([
+    "bramble/ChannelUtils",
+    "thirdparty/filer/dist/filer.min"
+], function(ChannelUtils, Filer) {
+    "use strict";
+
+    var Buffer = Filer.Buffer;
+    var UUID = ChannelUtils.UUID;
+    // Remote callbacks
+    var callbackQueue = {};
+
+    function RemoteIndexedDBContext(worker, mode) {
+        this.worker = worker;
+        this.mode = mode;
+    }
+
+    RemoteIndexedDBContext.prototype.proxyCall = function(method, options, callback) {
+        var that = this;
+        var id = UUID.generate();
+        callbackQueue[id] = callback;
+        this.worker.postMessage({
+            method: method,
+            mode: that.mode,
+            callback: id,
+            args: options.args
+        });
+    };
+
+    RemoteIndexedDBContext.prototype.clear = function(callback) {
+        this.proxyCall("clear", {args: null}, callback);
+    };
+
+    RemoteIndexedDBContext.prototype.getObject = function(key, callback) {
+        this.proxyCall("getObject", {args: [key]}, callback);
+    };
+    RemoteIndexedDBContext.prototype.getBuffer = function(key, callback) {
+        this.proxyCall("getBuffer", {args: [key]}, function(err, arrayBuffer) {
+            if(err) {
+                return callback(err);
+            }
+            callback(null, new Buffer(arrayBuffer));
+        });
+    };
+
+    RemoteIndexedDBContext.prototype.putObject = function(key, value, callback) {
+        this.proxyCall("putObject", {args: [key, value]}, callback);
+    };
+    RemoteIndexedDBContext.prototype.putBuffer = function(key, uint8BackedBuffer, callback) {
+        var buf;
+        if(!Buffer._useTypedArrays) { // workaround for fxos 1.3
+            buf = uint8BackedBuffer.toArrayBuffer();
+        } else {
+            buf = uint8BackedBuffer.buffer;
+        }
+
+        this.proxyCall("putBuffer", {args: [key, buf]}, callback);
+    };
+
+    RemoteIndexedDBContext.prototype.delete = function(key, callback) {
+        this.proxyCall("delete", {args: [key]}, callback);
+    };
+
+
+    function RemoteIndexedDB(name, worker) {
+        this.name = name;
+        this.worker = worker;
+    }
+    RemoteIndexedDB.isSupported = function() {
+        // Callers need to check before using this.
+        return "maybe";
+    };
+
+    RemoteIndexedDB.prototype.open = function(callback) {
+        var that = this;
+
+        function run() {
+            function remoteCallbackHandler(e) {
+                var data = e.data;
+                var callback = callbackQueue[data.callback];
+                delete callbackQueue[data.callback];
+                callback.apply(null, data.result);
+            }
+            that.worker.addEventListener("message", remoteCallbackHandler, false);
+
+            callback();
+        }
+
+        function handleOpen(e) {
+            that.worker.removeEventListener("message", handleOpen, false);
+            var data = e.data;
+
+            if(data.type !== "OPEN_CALLBACK") {
+                return callback(new Error("unexpected worker message: " + e.data.type));
+            }
+
+            if(data.err) {
+                return callback(data.err);
+            }
+
+            run();
+        }
+        that.worker.addEventListener("message", handleOpen, false);
+        that.worker.postMessage({type: "OPEN", name: that.name});
+    };
+    RemoteIndexedDB.prototype.getReadOnlyContext  = 
+    RemoteIndexedDB.prototype.getReadWriteContext = function() {
+        return new RemoteIndexedDBContext(this.worker);
+    };
+
+    return RemoteIndexedDB;
+});

--- a/src/bramble/client/RemoteIndexedDB.js
+++ b/src/bramble/client/RemoteIndexedDB.js
@@ -12,9 +12,10 @@ define([
     // Remote callbacks
     var callbackQueue = {};
 
-    function RemoteIndexedDBContext(worker, mode) {
+    function RemoteIndexedDBContext(worker, mode, useTransferables) {
         this.worker = worker;
         this.mode = mode;
+        this.useTransferables = useTransferables;
     }
 
     RemoteIndexedDBContext.prototype.proxyCall = function(method, options, callback) {
@@ -64,9 +65,10 @@ define([
     };
 
 
-    function RemoteIndexedDB(name, worker) {
+    function RemoteIndexedDB(name, worker, useTransferables) {
         this.name = name;
         this.worker = worker;
+        this.useTransferables = useTransferables;
     }
     RemoteIndexedDB.isSupported = function() {
         // Callers need to check before using this.
@@ -105,9 +107,11 @@ define([
         that.worker.addEventListener("message", handleOpen, false);
         that.worker.postMessage({type: "OPEN", name: that.name});
     };
-    RemoteIndexedDB.prototype.getReadOnlyContext  = 
+    RemoteIndexedDB.prototype.getReadOnlyContext  = function() {
+        return new RemoteIndexedDBContext(this.worker, "readonly", this.useTransferables);
+    };
     RemoteIndexedDB.prototype.getReadWriteContext = function() {
-        return new RemoteIndexedDBContext(this.worker);
+        return new RemoteIndexedDBContext(this.worker, "readwrite", this.useTransferables);
     };
 
     return RemoteIndexedDB;

--- a/src/bramble/client/main.js
+++ b/src/bramble/client/main.js
@@ -94,7 +94,6 @@ define([
 
     // Expose Filer for Path, Buffer, providers, etc.
     Bramble.Filer = Filer;
-    debugger;
     var _fs = new Filer.FileSystem({provider: new HybridIndexedDBProvider()});
     Bramble.getFileSystem = function() {
         return _fs;

--- a/src/bramble/client/main.js
+++ b/src/bramble/client/main.js
@@ -29,8 +29,9 @@ define([
     "bramble/ChannelUtils",
     "bramble/thirdparty/EventEmitter/EventEmitter.min",
     "bramble/client/StateManager",
+    "bramble/client/HybridIndexedDBProvider",
     "bramble/thirdparty/MessageChannel/message_channel"
-], function(Filer, ChannelUtils, EventEmitter, StateManager) {
+], function(Filer, ChannelUtils, EventEmitter, StateManager, HybridIndexedDBProvider) {
     "use strict";
 
     // PROD URL for Bramble, which can be changed below
@@ -93,7 +94,8 @@ define([
 
     // Expose Filer for Path, Buffer, providers, etc.
     Bramble.Filer = Filer;
-    var _fs = new Filer.FileSystem();
+    debugger;
+    var _fs = new Filer.FileSystem({provider: new HybridIndexedDBProvider()});
     Bramble.getFileSystem = function() {
         return _fs;
     };


### PR DESCRIPTION
I was doing some perf audits and noticed that filesystem calls are more expensive on the main thread that I thought, especially during startup when we read/write a lot from disk.

I did an experiment to move the filesystem db operations into a worker.  I'm not sure if this is a good idea or not, I'll have to collect some data.  But it's working, if you want to try it out.
