### PR TITLE
Expose Selfie Dialog on Bramble API

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,6 +347,7 @@ to be notified when the action completes:
 * `showTutorial([callback])` - shows tutorial (i.e., tutorial.html) vs editor contents in preview
 * `hideTutorial([callback])` - stops showing tutorial (i.e., tutorial.html) and uses editor contents in preview
 * `showUploadFilesDialog([callback])` - shows the Upload Files dialog, allowing users to drag-and-drop, upload a file, or take a selfie.
+* `showSelfieDialog([callback])` - shows the Take a Selfie dialog, allowing users to use their built-in camera to take a selfie.
 * `addNewFile([options, callback])` - adds a new text file, using the provided options, which can include: `filename` a `String` with the complete filename to use; `contents` a `String` with the new text file's data; `ext` a `String` with the new file's extension; `basenamePrefix` a `String` with the basename to use when generating a new filename.  NOTE: if you provide `filename`, `basenamePrefix` and `ext` are ignored.
 * `addNewFolder([callback])` - adds a new folder.
 * `export([callback])` - creates an archive `.zip` file of the entire project's filesystem, and downloads it to the browser.

--- a/src/bramble/client/main.js
+++ b/src/bramble/client/main.js
@@ -850,6 +850,10 @@ define([
         this._executeRemoteCommand({commandCategory: "bramble", command: "BRAMBLE_SHOW_UPLOAD_FILES_DIALOG"}, callback);
     };
 
+    BrambleProxy.prototype.showSelfieDialog = function(callback) {
+        this._executeRemoteCommand({commandCategory: "bramble", command: "BRAMBLE_SHOW_SELFIE_DIALOG"}, callback);
+    };
+
     BrambleProxy.prototype.addNewFile = function(options, callback) {
         // We only support writing textual data this way
         if(typeof(options.contents) !== "string") {

--- a/src/extensions/default/bramble/lib/RemoteCommandHandler.js
+++ b/src/extensions/default/bramble/lib/RemoteCommandHandler.js
@@ -128,8 +128,13 @@ define(function (require, exports, module) {
         case "BRAMBLE_HIDE_TUTORIAL":
             Tutorial.setOverride(false);
             break;
+        case "BRAMBLE_SHOW_SELFIE_DIALOG":
+            // Show selfie dialog, see extensions/default/BrambleUrlCodeHints
+            skipCallback = true;
+            CommandManager.execute("bramble.selfie").always(callback);
+            break;
         case "BRAMBLE_SHOW_UPLOAD_FILES_DIALOG":
-            // Show dialog, see extensions/default/UploadFiles
+            // Show upload files dialog, see extensions/default/UploadFiles
             skipCallback = true;
             CommandManager.execute("bramble.showUploadFiles").always(callback);
             break;


### PR DESCRIPTION
This adds a mechanism for hosting apps to trigger the selfie dialog, which is needed for https://github.com/mozilla/thimble.webmaker.org/issues/1215
