### PR TITLE
Fix #533 - Make sure string files are updated on staging

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -65,7 +65,6 @@ module.exports = function (grunt) {
                     cwd: 'src/',
                     src: [
                         /* static files */
-                        'nls/{,*/}*.js',
                         'xorigin.js',
                         'dependencies.js',
                         'thirdparty/requirejs/require.js',
@@ -91,6 +90,14 @@ module.exports = function (grunt) {
                         'thirdparty/text/*.js'
                     ],
                     dest: 'dist/'
+                }]
+            },
+            nls: {
+                files: [{
+                    expand: true,
+                    cwd: 'dist/nls',
+                    src: [ '**/*.js' ],
+                    dest: 'dist/nls'
                 }]
             }
         },


### PR DESCRIPTION
The wrong working directory was used for the *built* string files (a combination of Brackets' and our strings) and so uglify was using the string files from `src` which only had Brackets' strings and was overwriting the built ones with it.