### PR TITLE
Backend pieces of auto-update enable/disable

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,6 +341,8 @@ to be notified when the action completes:
 * `useDesktopPreview([callback])` - uses a Desktop view in the preview, as it would look on a desktop computer (default)
 * `enableFullscreenPreview([callback])` - shows a fullscreen preview of the current file
 * `disableFullscreenPreview([callback])` - turns off the fullscreen preview of the curent file
+* `enableAutoUpdate([callback])` - turns on auto-update for the preview (default)
+* `disableAutoUpdate([callback])` - turns off auto-update for the preview (manual reloads still work)
 * `enableJavaScript([callback])` - turns on JavaScript execution for the preview (default)
 * `disableJavaScript([callback])` - turns off JavaScript execution for the preview
 * `enableInspector([callback])` - turns on the preview inspector (shows code for hovered/clicked element)

--- a/src/bramble/client/main.js
+++ b/src/bramble/client/main.js
@@ -814,6 +814,14 @@ define([
         this._executeRemoteCommand({commandCategory: "bramble", command: "BRAMBLE_DISABLE_FULLSCREEN_PREVIEW"}, callback);
     };
 
+    BrambleProxy.prototype.enableAutoUpdate = function(callback) {
+        this._executeRemoteCommand({commandCategory: "bramble", command: "BRAMBLE_ENABLE_AUTO_UPDATE"}, callback);
+    };
+
+    BrambleProxy.prototype.disableAutoUpdate = function(callback) {
+        this._executeRemoteCommand({commandCategory: "bramble", command: "BRAMBLE_DISABLE_AUTO_UPDATE"}, callback);
+    };
+
     BrambleProxy.prototype.enableJavaScript = function(callback) {
         this._executeRemoteCommand({commandCategory: "bramble", command: "BRAMBLE_ENABLE_SCRIPTS"}, callback);
     };

--- a/src/extensions/default/bramble/lib/PostMessageTransport.js
+++ b/src/extensions/default/bramble/lib/PostMessageTransport.js
@@ -201,10 +201,31 @@ define(function (require, exports, module) {
     // URL of document being rewritten/launched (if any)
     var _pendingReloadUrl;
 
-    function reload() {
+    // Whether or not to allow reloads in the general case (true by default)
+    var _autoUpdate = true;
+
+    function setAutoUpdate(value) {
+        _autoUpdate = value;
+
+        // Force a reload if we switch back to auto-updates
+        if(_autoUpdate) {
+            reload(true);
+        }
+    }
+
+    /**
+     * Reload the LiveDev preview if not auto-updates aren't disabled.
+     * If force=true, we ignore the current state of auto-updates and do it.
+     */
+    function reload(force) {
         var launcher = Launcher.getCurrentInstance();
         var liveDoc = LiveDevMultiBrowser._getCurrentLiveDoc();
         var url;
+
+        // If auto-updates are disabled, and force wasn't passed, bail.
+        if(!_autoUpdate && !force) {
+            return;
+        }
 
         // Don't go any further if we don't have a live doc yet (nothing to reload)
         if(!liveDoc) {
@@ -226,6 +247,7 @@ define(function (require, exports, module) {
 
     // Exports
     module.exports.getRemoteScript = getRemoteScript;
+    module.exports.setAutoUpdate   = setAutoUpdate;
     module.exports.setIframe       = setIframe;
     module.exports.start           = start;
     module.exports.send            = send;

--- a/src/extensions/default/bramble/lib/RemoteCommandHandler.js
+++ b/src/extensions/default/bramble/lib/RemoteCommandHandler.js
@@ -69,7 +69,7 @@ define(function (require, exports, module) {
         case "BRAMBLE_RELOAD":
             // If JS is disabled, re-enable it just for this next reload.
             HTMLRewriter.forceScriptsOnce();
-            PostMessageTransport.reload();
+            PostMessageTransport.reload(true);
             break;
         case "BRAMBLE_MOBILE_PREVIEW":
             UI.showMobileView();
@@ -82,6 +82,12 @@ define(function (require, exports, module) {
             break;
         case "BRAMBLE_DISABLE_FULLSCREEN_PREVIEW":
             UI.disableFullscreenPreview();
+            break;
+        case "BRAMBLE_ENABLE_AUTO_UPDATE":
+            PostMessageTransport.setAutoUpdate(true);
+            break;
+        case "BRAMBLE_DISABLE_AUTO_UPDATE":
+            PostMessageTransport.setAutoUpdate(false);
             break;
         case "BRAMBLE_ENABLE_SCRIPTS":
             HTMLRewriter.enableScripts();


### PR DESCRIPTION
This updates Brackets for the API changes necessary for https://github.com/mozilla/thimble.mozilla.org/issues/1417.

There are 2 types of "reloads" that we do.  The first is a full reload for cases where the DOM needs to be altered in a way that can't be done easily, which is like refreshing the browser tab.  The second is a dynamic injection of content that doesn't warrant a full reload.  For example, updating the text in a paragraph tag.

This patch makes it possible to stop the first kind of reload, which is what I think we want.  If we decide that we also want to stop the second type, it's going to be hacky.  I would need to inspect messages going over the LiveDev transport, and look for things like `"_LD.applyDOMEdits([{"type":"textReplace"...` deep inside the string of a `Runtime.evaluate` message.  I could do this, but if I don't have to, I'd rather not.

cc @flukeout 
r? @gideonthomas  