### PR TITLE
Properly clean src/nls/* when doing grunt unlocalize

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -517,7 +517,7 @@ module.exports = function (grunt) {
         exec: {
             localize: 'node scripts/properties2js',
             'localize-dist': 'node scripts/properties2js dist',
-            'clean-nls': 'git checkout -- src/nls'
+            'clean-nls': 'rm -fr src/nls && git checkout -- src/nls'
         }
     });
 


### PR DESCRIPTION
The current `grunt unlocalize` leaves a bunch of dirs in `src/nls/` that are wrong:

```
Untracked files:
  (use "git add <file>..." to include in what will be committed)

	src/nls/bn-bd/
	src/nls/dsb/
	src/nls/es-cl/
	src/nls/hsb/
	src/nls/sl/
	src/nls/sv-se/
```

This change forces the `nls/src/` dir to get cleaned before we restore its proper state from the repo.