### PR TITLE
Fix SW cacheId to be stable (don't use date/time suffix)

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -592,7 +592,7 @@ module.exports = function (grunt) {
         }());
 
         var config = {
-            cacheId: 'bramble-cache::' + Date.now(),
+            cacheId: 'bramble',
             logger: grunt.log.writeln,
             staticFileGlobs: files,
             stripPrefix: 'dist/',


### PR DESCRIPTION
I think I messed up how I name my SW cache.  This fixes thing so that the cache name is always stable, which is what I see everyone else doing with it.