### PR TITLE
Fix https://github.com/mozilla/thimble.mozilla.org/issues/1492

### DIFF
--- a/src/extensions/default/bramble-move-file/styles/style.css
+++ b/src/extensions/default/bramble-move-file/styles/style.css
@@ -1,6 +1,6 @@
 .modal-body {
     background-color: #fff;
-    overflow: auto;
+    overflow-y: auto;
 }
 
 .move-to-dialog {


### PR DESCRIPTION
It looks like the more specific `overflow-y` was what really needed to get reset.  This fixes if for me locally.