### PR TITLE
Trigger different events with different data for file vs. folder renames

### DIFF
--- a/README.md
+++ b/README.md
@@ -378,5 +378,14 @@ There are also high-level events for changes to files:
 * `"fileChange"` - triggered whenever a file is created or updated within the project root.  It includes the `filename` of the file that changed.
 * `"fileDelete"` - triggered whenever a file is deleted within the project root.  It includes the `filename` of the file that was deleted.
 * `"fileRename"` - triggered whenever a file is renamed within the project root.  It includes the `oldFilename` and the `newFilename` of the file that was renamed.
+* `"folderRename"` - triggered whenever a folder is renamed within the project root. It includes an object that looks something like this:
+```js
+{
+  oldPath: "/path/before/rename",
+  newPath: "/path/after/rename",
+  // Paths to all files contained inside the folder being renamed
+  children: [ "relativeFilePath1",  "relativeFilePath2", ... ]
+}
+```
 
 NOTE: if you want to receive generic events for file system events, especially events across windows using the same file system, use [fs.watch()](https://github.com/filerjs/filer#watch) instead.

--- a/src/bramble/client/main.js
+++ b/src/bramble/client/main.js
@@ -504,11 +504,27 @@ define([
                     callback(err);
                 };
             }
-            // Renames are special, since we care about both filenames
+            // File Renames are special, since we care about both filenames
             function renameFileEventFn(type, oldFilename, newFilename, callback) {
                 return function(err) {
                     if(!err) {
                         self.trigger(type, [oldFilename, newFilename]);
+                    }
+                    callback(err);
+                };
+            }
+
+            // Folder Renames are special since we care about the old name,
+            // the new name and all the child paths that were changed as a
+            // result of the rename
+            function renameFolderEventFn(type, oldFolderPath, newFolderPath, folderChildren, callback) {
+                return function(err) {
+                    if(!err) {
+                        self.trigger(type, [{
+                            oldPath: oldFolderPath,
+                            newPath: newFolderPath,
+                            children: folderChildren
+                        }]);
                     }
                     callback(err);
                 };
@@ -588,6 +604,27 @@ define([
                 });
             }
 
+            function getChildrenOfFolder(folderPath, callback) {
+                var children = [];
+
+                function storeRelativePath(childPath, next) {
+                    // We don't care about child folders, only files
+                    if(!childPath.endsWith("/")) {
+                        children.push(Path.relative(folderPath, childPath));
+                    }
+
+                    next();
+                }
+
+                shell.find(folderPath, { exec: storeRelativePath }, function(err) {
+                    if(err) {
+                        callback(err);
+                    } else {
+                        callback(null, children);
+                    }
+                });
+            }
+
             // Most fs methods can just get run normally, but we have to deal with
             // ArrayBuffer vs. Filer.Buffer for readFile and writeFile, and persist
             // watch callbacks. We also deal with the special case of `tutorial.html`.
@@ -607,22 +644,46 @@ define([
                 }));
                 break;
             case "rename":
-                wrappedCallback = renameFileEventFn("fileRename", args[0], args[1], callback);
-                _fs.rename.apply(_fs, args.concat(function(err) {
-                    if(!err) {
-                        // If we rename tutorial.html to something else, we're removing it
-                        if(args[0] === self.tutorialPath) {
-                            wrappedCallback = genericFileEventFn("tutorialRemoved", args[0], wrappedCallback);
-                            _tutorialExists = false;
-                        }
-                        // If we rename something to tutorial.html, we're adding a tutorial
-                        else if(args[1] === self.tutorialPath) {
-                            wrappedCallback = genericFileEventFn("tutorialAdded", args[1], wrappedCallback);
-                            _tutorialExists = true;
-                        }
+                // We need to check if the rename is happening on a file or a
+                // folder and accordingly trigger the right event and send the
+                // right data needed by the event listener
+                _fs.stat(args[0], function(err, stats) {
+                    if(err) {
+                        callback(err);
+                    } else if(stats.isDirectory()) {
+                        getChildrenOfFolder(args[0], function(err, children) {
+                            if(err) {
+                                callback(err);
+                            } else {
+                                _fs.rename.apply(
+                                    _fs,
+                                    args.concat(renameFolderEventFn(
+                                        "folderRename",
+                                        args[0], args[1], children,
+                                        callback
+                                    ))
+                                );
+                            }
+                        });
+                    } else {
+                        wrappedCallback = renameFileEventFn("fileRename", args[0], args[1], callback);
+                        _fs.rename.apply(_fs, args.concat(function(err) {
+                            if(!err) {
+                                // If we rename tutorial.html to something else, we're removing it
+                                if(args[0] === self.tutorialPath) {
+                                    wrappedCallback = genericFileEventFn("tutorialRemoved", args[0], wrappedCallback);
+                                    _tutorialExists = false;
+                                }
+                                // If we rename something to tutorial.html, we're adding a tutorial
+                                else if(args[1] === self.tutorialPath) {
+                                    wrappedCallback = genericFileEventFn("tutorialAdded", args[1], wrappedCallback);
+                                    _tutorialExists = true;
+                                }
+                            }
+                            wrappedCallback(err);
+                        }));
                     }
-                    wrappedCallback(err);
-                }));
+                });
                 break;
             case "unlink":
                 path = args[0];

--- a/src/bramble/client/main.js
+++ b/src/bramble/client/main.js
@@ -608,7 +608,10 @@ define([
                 var children = [];
 
                 function storeRelativePath(childPath, next) {
-                    // We don't care about child folders, only files
+                    // We don't care about child folders, only files because
+                    // the current user of Bramble viz. Thimble does not keep
+                    // track of folder paths and hence including them would be
+                    // redundant (possibly problematic)
                     if(!childPath.endsWith("/")) {
                         children.push(Path.relative(folderPath, childPath));
                     }


### PR DESCRIPTION
This patch treats file renames and folder renames as different events. 
* With file renames, we trigger the `fileRename` event and send the old file path and the new file path (nothing has changed here)
* With folder renames, we trigger the `folderRename` event and send only one object that contains the old folder path, the new folder path and an array of relative paths of files that live in the folder that is about to be renamed.

This will allow us to fix mozilla/thimble.mozilla.org#1311 and is part of a 3-piece patch (this patch depends on a patch in publish.wm.org landing first that adds a route for folder renames, then this patch should be landed along with the corresponding patch in thimble.mozilla.org). I haven't tested this yet since I'm waiting on another patch in publish to land first before I write the patch that will add the folder rename route...then I can test this.

@humphd r?