### PR TITLE
Watch and warn on rename or delete events for the root index.html file

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -397,7 +397,8 @@ module.exports = function (grunt) {
                 '<%= meta.src %>',
                 '<%= meta.test %>',
                 '!src/extensions/extra/**',
-                '!src/bramble/thirdparty/**'
+                '!src/bramble/thirdparty/**',
+                '!src/nls/**'
             ],
             grunt:  '<%= meta.grunt %>',
             src:    [
@@ -406,7 +407,8 @@ module.exports = function (grunt) {
                 '!src/extensions/default/HTMLHinter/slowparse/**',
                 '!src/extensions/default/HTMLHinter/tooltipsy.source.js',
                 '!src/extensions/extra/**',
-                '!src/bramble/thirdparty/**'
+                '!src/bramble/thirdparty/**',
+                '!src/nls/**'
             ],
             test:   '<%= meta.test %>',
             /* use strict options to mimic JSLINT until we migrate to JSHINT in Brackets */

--- a/locales/en-US/editor.properties
+++ b/locales/en-US/editor.properties
@@ -189,8 +189,3 @@ ERROR_MOVING_FILE_DIALOG_HEADER=Move Error
 UNEXPECTED_ERROR_MOVING_FILE=An unexpected error occurred when attempting to move {0} to {1}
 # {0} is the name of the file/folder being moved and {1} is the name of the folder it is being moved to
 ERROR_MOVING_FILE_SAME_NAME=A file or folder with the name {0} already exists in {1}. Consider renaming either one to continue.
-
-# extensions/extra/bramble-watch-index.html
-
-INDEX_HTML_FILE_MISSING_DIALOG_TITLE=Warning - Missing index.html file
-INDEX_HTML_FILE_MISSING_DIALOG_MESSAGE=Your project has no index.html file. Web servers look for index.html when URLs omit the filename, for example: google.com/ actually refers to google.com/index.html. Consider adding an index.html.

--- a/locales/en-US/editor.properties
+++ b/locales/en-US/editor.properties
@@ -189,3 +189,8 @@ ERROR_MOVING_FILE_DIALOG_HEADER=Move Error
 UNEXPECTED_ERROR_MOVING_FILE=An unexpected error occurred when attempting to move {0} to {1}
 # {0} is the name of the file/folder being moved and {1} is the name of the folder it is being moved to
 ERROR_MOVING_FILE_SAME_NAME=A file or folder with the name {0} already exists in {1}. Consider renaming either one to continue.
+
+# extensions/extra/bramble-watch-index.html
+
+INDEX_HTML_FILE_MISSING_DIALOG_TITLE=Warning - Missing index.html file
+INDEX_HTML_FILE_MISSING_DIALOG_MESSAGE=Your project has no index.html file. Web servers look for index.html when URLs omit the filename, for example: google.com/ actually refers to google.com/index.html. Consider adding an index.html.

--- a/scripts/properties2js.js
+++ b/scripts/properties2js.js
@@ -171,6 +171,10 @@ function run() {
 
     return fs.readdirAsync(src)
     .then(function(folders) {
+        var DSStoreIndex = folders.indexOf(".DS_Store");
+        if(DSStoreIndex > -1) {
+            folders.splice(DSStoreIndex, 1);
+        }
         locales = folders;
         return Promise.map(locales, getExistingLocalizedContent, CONCURRENCY);
     })

--- a/src/extensions/extra/bramble-watch-index.html/main.js
+++ b/src/extensions/extra/bramble-watch-index.html/main.js
@@ -1,0 +1,68 @@
+/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
+/*global define, brackets, clearTimeout, setTimeout */
+
+define(function (require, exports, module) {
+    "use strict";
+
+    /**
+     * Thimble extension for Bramble to watch for, and warn about, renames and
+     * deletes to the project's root index.html file.  Too many users are confused
+     * by projects without an index.html file returning a 404 when they browse to the
+     * root dir / of the published project.  See 
+     * https://github.com/mozilla/thimble.mozilla.org/issues/1569#issuecomment-258889724
+     */
+
+    var AppInit              = brackets.getModule("utils/AppInit"),
+        Strings              = brackets.getModule("strings"),
+        FileSystem           = brackets.getModule("filesystem/FileSystem"),
+        BrambleStartupState  = brackets.getModule("bramble/StartupState"),
+        Filer                = brackets.getModule("filesystem/impls/filer/BracketsFiler"),
+        Path                 = Filer.Path,
+        Dialogs              = brackets.getModule("widgets/Dialogs"),
+        DefaultDialogs       = brackets.getModule("widgets/DefaultDialogs");
+
+    // Let the user know that the root index.html file is now missing (i.e., was
+    // removed/renamed) and that this will affect loading (e.g., / vs. /index.html).
+    function warn() {
+        var dialog = Dialogs.showModalDialog(
+            DefaultDialogs.DIALOG_ID_INFO,
+            Strings.INDEX_HTML_FILE_MISSING_DIALOG_TITLE,
+            Strings.INDEX_HTML_FILE_MISSING_DIALOG_MESSAGE
+        );
+    }
+
+    function init() {
+        var indexPath = Path.join(BrambleStartupState.project("root"), "index.html");
+        
+        // Listen for delete events for the root index.html
+        FileSystem.on("change", function(evt, entry, added, removed) {
+            // Ignore non-dir change events.  A file being deleted will be part
+            // of a change to its parent dir.
+            if(!entry || !entry.isDirectory) {
+                return;
+            }
+
+            // Ignore change events without `removed` entries
+            if(!removed || removed.length === 0) {
+                return;
+            }
+
+            // Check all the removed entries to see if any of them are the root index.html file
+            for(var file, i = 0; i < removed.length; i++) {
+                file = removed[i];
+                if(file.fullPath === indexPath) {
+                    return warn();
+                }
+            }
+        });
+
+        // Listen for rename events on the root index.html
+        FileSystem.on("rename", function(evt, oldPath, newPath) {
+            if(oldPath === indexPath) {
+                warn();
+            }
+        });
+    }
+
+    AppInit.appReady(init);
+});

--- a/src/extensions/extra/bramble-watch-index.html/main.js
+++ b/src/extensions/extra/bramble-watch-index.html/main.js
@@ -1,5 +1,5 @@
 /*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, brackets, clearTimeout, setTimeout */
+/*global define, brackets */
 
 define(function (require, exports, module) {
     "use strict";

--- a/src/utils/BrambleExtensionLoader.js
+++ b/src/utils/BrambleExtensionLoader.js
@@ -65,7 +65,8 @@ define(function (require, exports, module) {
         "brackets-cdn-suggestions",    // https://github.com/szdc/brackets-cdn-suggestions
         "HTMLHinter",
         "MDNDocs",
-        "SVGasXML"
+        "SVGasXML",
+        "bramble-watch-index.html"
     ];
 
     // Disable any extensions we found on the query string's disableExtensions param

--- a/sw-cache-file-list.json
+++ b/sw-cache-file-list.json
@@ -150,6 +150,8 @@
         "dist/extensions/default/bramble-move-file/htmlContent/move-to-dialog.html",
         "dist/extensions/default/bramble-move-file/htmlContent/directory-tree.html",
         "dist/extensions/default/bramble-move-file/styles/style.css",
-        "dist/extensions/default/bramble-move-file/images/*.svg"
+        "dist/extensions/default/bramble-move-file/images/*.svg",
+
+        "dist/extensions/extra/bramble-watch-index.html/main.js"
     ]
 }


### PR DESCRIPTION
This is part of https://github.com/mozilla/thimble.mozilla.org/issues/1569#issuecomment-258889724.  It adds an extra extension (not loaded by default--it will need to be enabled in Thimble) to watch and warn on any delete or rename to the project's root `index.html` file.

To test this, do the following:
* `npm run build`
* `npm start`
* load http://localhost:8000/src/hosted.html?enableExtensions=bramble-watch-index.html (NOTE: the extension must be manually enabled in the URL)
* Make sure you have an `index.html` file, then try right-clicking and `Rename` and `Delete`.  Both should show a modal dialog with info.

I'm not sure if the text I've got in the dialog is right.  I want to do another patch in Thimble that offers to create an `index.html` on publish, but decided to only warn about the issue here.

I've also added jshint excludes for `src/nls` to stop jshint complaining about strings as if they are code, and breaking the build.

r? @gideonthomas, @flukeout 