### PR TITLE
Remove unexpected indent/unindent behaviour when pressing CMD on Mac

### DIFF
--- a/src/base-config/keyboard.json
+++ b/src/base-config/keyboard.json
@@ -70,16 +70,6 @@
             "displayKey": "Shift-Alt-↓"
         }
     ],
-    "edit.indent":  [
-        {
-            "key": "Ctrl-]"
-        }
-    ],
-    "edit.unindent":  [
-        {
-            "key": "Ctrl-["
-        }
-    ],
     "edit.duplicate":  [
         "Ctrl-D"
     ],


### PR DESCRIPTION
This fixes https://github.com/mozilla/thimble.mozilla.org/issues/1572 in a somewhat heavy-handed way by disabling the `Ctrl-[` and `Ctrl-]` (and `CMD` on Mac) indent, unindent keybindings.  When elements are selected in the editor, pressing `CMD` sends `CMD-[` or `CMD-]` depending on whether you press left or right `CMD`.  For our purposes, and users, this is unexpected and makes it hard to use `CMD-` style keybindings.