### PR TITLE
Update http-server to 0.9.0 for non-ascii path support

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "devDependencies": {
         "bluebird": "3.2.2",
         "gunzip-maybe": "^1.3.1",
-        "http-server": "^0.8.0",
+        "http-server": "^0.9.0",
         "mkdirp": "0.5.1",
         "nunjucks": "2.3.0",
         "properties-parser": "0.3.1",


### PR DESCRIPTION
The http-server module breaks with non-eng characters in file paths, see https://github.com/angular/angular-phonecat/issues/303. This updates it to 0.9.0 with fix the bug.