### PR TITLE
Fix Issue with file disappearance upon renaming error

### DIFF
--- a/src/bramble/client/main.js
+++ b/src/bramble/client/main.js
@@ -510,6 +510,7 @@ define([
                     if(!err) {
                         self.trigger(type, [oldFilename, newFilename]);
                     }
+                    self.trigger(type,[oldFilename,oldFilename]);
                     callback(err);
                 };
             }


### PR DESCRIPTION
This Issue was brought up on thimble

[Here](https://github.com/mozilla/thimble.mozilla.org/issues/1673)

and the issue links back to brackets.

renaming file error with filenames greater than the size of the window pane causes the view to be shifted to the right and viewed as if the files disappeared. The solution was to move back to its original location to prevent the illusion of the file disappearance.