### PR TITLE
Fix #1632: Added new limits for text font size in editor

### DIFF
--- a/src/view/ViewCommandHandlers.js
+++ b/src/view/ViewCommandHandlers.js
@@ -67,7 +67,7 @@ define(function (require, exports, module) {
      * The smallest font size in pixels
      * @type {number}
      */
-    var MIN_FONT_SIZE = 1;
+    var MIN_FONT_SIZE = 8;
 
     /**
      * @const
@@ -75,7 +75,7 @@ define(function (require, exports, module) {
      * The largest font size in pixels
      * @type {number}
      */
-    var MAX_FONT_SIZE = 72;
+    var MAX_FONT_SIZE = 32;
 
     /**
      * @const


### PR DESCRIPTION
Added new limits to the font size of the editor, this issue was specified here : https://github.com/mozilla/thimble.mozilla.org/issues/1632

Minimum : 8
Maximum : 32