### PR TITLE
Rename File Error when Copy/Past Index.html content to file tree

### DIFF
--- a/src/bramble/client/main.js
+++ b/src/bramble/client/main.js
@@ -510,6 +510,7 @@ define([
                     if(!err) {
                         self.trigger(type, [oldFilename, newFilename]);
                     }
+                    self.trigger(type,[oldFilename,oldFilename]);
                     callback(err);
                 };
             }

--- a/src/bramble/client/main.js
+++ b/src/bramble/client/main.js
@@ -510,7 +510,6 @@ define([
                     if(!err) {
                         self.trigger(type, [oldFilename, newFilename]);
                     }
-                    self.trigger(type,[oldFilename,oldFilename]);
                     callback(err);
                 };
             }

--- a/src/project/ProjectManager.js
+++ b/src/project/ProjectManager.js
@@ -635,7 +635,7 @@ define(function (require, exports, module) {
         if (!projectRoot) {
             return;
         }
-        //We don't want to allow the user to scroll off the right, hiding the files
+        //XXXbramble: We don't want to allow the user to scroll off the right, hiding the files
         model.setScrollerInfo($projectTreeContainer[0].scrollWidth, $projectTreeContainer.scrollTop(), 0, $projectTreeContainer.offset().top);
         FileTreeView.render(fileTreeViewContainer, model._viewModel, projectRoot, actionCreator, forceRender, brackets.platform);
     };

--- a/src/project/ProjectManager.js
+++ b/src/project/ProjectManager.js
@@ -635,7 +635,7 @@ define(function (require, exports, module) {
         if (!projectRoot) {
             return;
         }
-        model.setScrollerInfo($projectTreeContainer[0].scrollWidth, $projectTreeContainer.scrollTop(), $projectTreeContainer.scrollLeft(), $projectTreeContainer.offset().top);
+        model.setScrollerInfo($projectTreeContainer[0].scrollWidth, $projectTreeContainer.scrollTop(), 0, $projectTreeContainer.offset().top);
         FileTreeView.render(fileTreeViewContainer, model._viewModel, projectRoot, actionCreator, forceRender, brackets.platform);
     };
 

--- a/src/project/ProjectManager.js
+++ b/src/project/ProjectManager.js
@@ -635,6 +635,7 @@ define(function (require, exports, module) {
         if (!projectRoot) {
             return;
         }
+        //We don't want to allow the user to scroll off the right, hiding the files
         model.setScrollerInfo($projectTreeContainer[0].scrollWidth, $projectTreeContainer.scrollTop(), 0, $projectTreeContainer.offset().top);
         FileTreeView.render(fileTreeViewContainer, model._viewModel, projectRoot, actionCreator, forceRender, brackets.platform);
     };


### PR DESCRIPTION
Original issue was posted here.
[Here](https://github.com/mozilla/thimble.mozilla.org/issues/1673)

Providing a long path to a file with an invalid file path causes an error where the file tree view appears to have disappeared. The file tree view did not recenter itself back to its original position so the user would have to scroll all the way left to properly view the file tree. This fix forces the view to the left of the file tree.