### PR TITLE
Issue 841 - Adding right-click menu file highlight.

### DIFF
--- a/src/extensions/default/bramble/stylesheets/sidebarTheme.css
+++ b/src/extensions/default/bramble/stylesheets/sidebarTheme.css
@@ -33,7 +33,6 @@ li.jstree-closed>a>span {
 li.jstree-leaf>a>span.extension {
 	color: #666666;
 }
-
 .filetree-selection {
 	background-color: #333333;
 	border: none;
@@ -43,20 +42,20 @@ li.jstree-leaf>a>span.extension {
 	width: 100% !important;
 }
 .filetree-selection-extension {
-    opacity: 0;
+	opacity: 0;
 }
 .filetree-context {
-    background-color: rgba(255,255,255,0.12);
-    height: 27px;
+	background-color: rgba(255,255,255,0.12);
+	height: 27px;
 }
 .filetree-context-extension {
-    opacity: 0;
+	opacity: 0;
 }
 .menu-name {
-    font-size: 15px;
+	font-size: 15px;
 }
 .context {
-   color: rgba(255,255,255,0.6); 
+	color: rgba(255,255,255,0.6); 
 }
 li.jstree-leaf>a.jstree-clicked>span {
 	color: white;

--- a/src/extensions/default/bramble/stylesheets/sidebarTheme.css
+++ b/src/extensions/default/bramble/stylesheets/sidebarTheme.css
@@ -43,14 +43,14 @@ li.jstree-leaf>a>span.extension {
 	width: 100% !important;
 }
 .filetree-selection-extension {
-    opacity: 0.0;
+    opacity: 0;
 }
 .filetree-context {
-    background-color: rgba(255,255,255,0.6);
+    background-color: rgba(255,255,255,0.12);
     height: 27px;
 }
 .filetree-context-extension {
-    opacity: 0.0;
+    opacity: 0;
 }
 .menu-name {
     font-size: 15px;

--- a/src/extensions/default/bramble/stylesheets/sidebarTheme.css
+++ b/src/extensions/default/bramble/stylesheets/sidebarTheme.css
@@ -34,6 +34,10 @@ li.jstree-leaf>a>span.extension {
 	color: #666666;
 }
 
+.menu-name {
+    font-size: 15px;
+}
+
 .filetree-selection {
 	background-color: #333333;
 	border: none;
@@ -46,9 +50,12 @@ li.jstree-leaf>a>span.extension {
 	background-color: #333333;
 	border: none;
 }
+.filetree-context {
+    color: white;
+    background-color: #2d9961;
+}
 .filetree-context-extension {
-	background-color: #00FF00;
-    left: auto;
+    opacity: 0.0;
 }
 
 li.jstree-leaf>a.jstree-clicked>span {

--- a/src/extensions/default/bramble/stylesheets/sidebarTheme.css
+++ b/src/extensions/default/bramble/stylesheets/sidebarTheme.css
@@ -46,6 +46,10 @@ li.jstree-leaf>a>span.extension {
 	background-color: #333333;
 	border: none;
 }
+.filetree-context-extension {
+	background-color: #00FF00;
+    left: auto;
+}
 
 li.jstree-leaf>a.jstree-clicked>span {
 	color: white;

--- a/src/extensions/default/bramble/stylesheets/sidebarTheme.css
+++ b/src/extensions/default/bramble/stylesheets/sidebarTheme.css
@@ -34,10 +34,6 @@ li.jstree-leaf>a>span.extension {
 	color: #666666;
 }
 
-.menu-name {
-    font-size: 15px;
-}
-
 .filetree-selection {
 	background-color: #333333;
 	border: none;
@@ -47,17 +43,21 @@ li.jstree-leaf>a>span.extension {
 	width: 100% !important;
 }
 .filetree-selection-extension {
-	background-color: #333333;
-	border: none;
+    opacity: 0.0;
 }
 .filetree-context {
-    color: white;
-    background-color: #2d9961;
+    background-color: rgba(255,255,255,0.6);
+    height: 27px;
 }
 .filetree-context-extension {
     opacity: 0.0;
 }
-
+.menu-name {
+    font-size: 15px;
+}
+.context {
+   color: rgba(255,255,255,0.6); 
+}
 li.jstree-leaf>a.jstree-clicked>span {
 	color: white;
 }


### PR DESCRIPTION
Hello,

I managed to fix the highlighting in the file-tree when right clicking to change to the theme color as seen below:
<img width="253" alt="screen shot 2017-02-07 at 7 29 35 pm" src="https://cloud.githubusercontent.com/assets/3598286/22719000/55095924-ed71-11e6-93eb-66666577a96b.png">

I've also tried out orange:

<img width="290" alt="screen shot 2017-02-07 at 7 37 49 pm" src="https://cloud.githubusercontent.com/assets/3598286/22719011/61eceed0-ed71-11e6-9b27-2e4a1ecbd679.png">

But decided to stick to the Mozilla Thimble colors. 

I did notice a quick bug if I kept the opacity of the "filetree-context-extension" class to anything visible when creating a folder as seen here:

<img width="213" alt="screen shot 2017-02-07 at 7 32 11 pm" src="https://cloud.githubusercontent.com/assets/3598286/22719053/8fb8edfa-ed71-11e6-9b31-9e09c0247cf3.png">

The problem is only present when creating the folder for the first time, after which it would go back to normal:
<img width="309" alt="screen shot 2017-02-07 at 7 20 44 pm" src="https://cloud.githubusercontent.com/assets/3598286/22719077/b4e68812-ed71-11e6-9015-fd96327ec6c9.png">

Let me know how this can be improved or if it needs changing:) 

Regards,

Th30
