### PR TITLE
Quick Edit symbol fix

### DIFF
--- a/src/base-config/keyboard.json
+++ b/src/base-config/keyboard.json
@@ -291,6 +291,9 @@
     ],
     "navigate.toggleQuickEdit":  [
         {
+            "key": "Alt-E"
+        },
+        {
             "key": "Ctrl-E"
         }
     ],

--- a/src/base-config/keyboard.json
+++ b/src/base-config/keyboard.json
@@ -292,9 +292,6 @@
     "navigate.toggleQuickEdit":  [
         {
             "key": "Ctrl-E"
-        },
-        {
-            "key": "Alt-E"
         }
     ],
     "navigate.toggleQuickDocs":  [


### PR DESCRIPTION
In the keyboard.json file there was additional key bind for Quick Edit `"key": "Alt-E".`

A function in brackets/dist/main.js replaces `Ctrl`, `Alt` to Mac equivalent. Then a function `c(e)` displays the symbol of the keys. Since the keyboard.json had `Alt` it caused it to display `⌥`

By removing `"key": "Alt-E"` it was able to interpret the correct symbol.

This pull request will resolve issue [#1528](https://github.com/mozilla/thimble.mozilla.org/issues/1528) in the thimble.mozilla.org repo