### PR TITLE
Fix mozilla/thimble.mozilla.org#1652

### DIFF
--- a/src/extensions/default/bramble/lib/RemoteEvents.js
+++ b/src/extensions/default/bramble/lib/RemoteEvents.js
@@ -132,8 +132,14 @@ define(function (require, exports, module) {
      */
     function loaded() {
         var initialFile = MainViewManager.getCurrentlyViewedFile();
-        var fullPath = initialFile.fullPath; // this is where the issue
-        var filename = Path.basename(fullPath);
+        var fullPath = "";
+        var filename = "";
+
+        // avoid exception when the editor is not viewing any file
+        if (initialFile) {
+            fullPath = initialFile.fullPath;
+            filename = Path.basename(fullPath);
+        }
 
         var $firstPane = $("#first-pane");
         var $secondPane = $("#second-pane");

--- a/src/extensions/default/bramble/lib/RemoteEvents.js
+++ b/src/extensions/default/bramble/lib/RemoteEvents.js
@@ -132,7 +132,7 @@ define(function (require, exports, module) {
      */
     function loaded() {
         var initialFile = MainViewManager.getCurrentlyViewedFile();
-        var fullPath = initialFile.fullPath;
+        var fullPath = initialFile.fullPath; // this is where the issue
         var filename = Path.basename(fullPath);
 
         var $firstPane = $("#first-pane");


### PR DESCRIPTION
Fix mozilla/thimble.mozilla.org#1652 - Thimble hangs when deleting last HTML file and refreshing browser.
