### PR TITLE
Added cursor pointer to the sidebar folder

### DIFF
--- a/src/extensions/default/bramble/stylesheets/sidebarTheme.css
+++ b/src/extensions/default/bramble/stylesheets/sidebarTheme.css
@@ -25,10 +25,12 @@ li.jstree-leaf>a>span {
 li.jstree-open>a>span {
 	font-size: 15px;
 	color: #666666;
+	cursor: pointer !important;
 }
 li.jstree-closed>a>span {
 	font-size: 15px;
 	color: #666666;
+        cursor: pointer !important;
 }
 li.jstree-leaf>a>span.extension {
 	color: #666666;

--- a/src/extensions/default/bramble/stylesheets/sidebarTheme.css
+++ b/src/extensions/default/bramble/stylesheets/sidebarTheme.css
@@ -24,7 +24,7 @@ li.jstree-leaf>a>span {
 }
 li.jstree-open>a>span {
 	font-size: 15px;
-	color: #666666;	
+	color: #666666;
 }
 li.jstree-closed>a>span {
 	font-size: 15px;

--- a/src/extensions/default/bramble/stylesheets/sidebarTheme.css
+++ b/src/extensions/default/bramble/stylesheets/sidebarTheme.css
@@ -24,13 +24,11 @@ li.jstree-leaf>a>span {
 }
 li.jstree-open>a>span {
 	font-size: 15px;
-	color: #666666;
-	cursor: pointer !important;
+	color: #666666;	
 }
 li.jstree-closed>a>span {
 	font-size: 15px;
 	color: #666666;
-        cursor: pointer !important;
 }
 li.jstree-leaf>a>span.extension {
 	color: #666666;

--- a/src/styles/jsTreeTheme.less
+++ b/src/styles/jsTreeTheme.less
@@ -76,7 +76,7 @@ li.jstree-closed > ul { display:none; }
     a:hover {
         color: @project-panel-text-1;
         font-size: 13px;
-        cursor: default;
+        cursor: pointer;
 
         &.jstree-clicked, &.jstree-clicked .extension {
             color: @open-working-file-name-highlight;


### PR DESCRIPTION
Fixed issue [#1703 ](https://github.com/mozilla/thimble.mozilla.org/issues/1703) 

Added `cursor: pointer !important;` to `li.jstree-open>a>span ` and `li.jstree-closed>a>span ` css file. 
<img width="372" alt="screen shot 2017-02-09 at 12 33 35 pm" src="https://cloud.githubusercontent.com/assets/14276579/22795259/0e302a7e-eec4-11e6-9860-772802e2d5af.png">
