### PR TITLE
Context menu updates

### DIFF
--- a/src/styles/bramble_overrides.css
+++ b/src/styles/bramble_overrides.css
@@ -1,3 +1,4 @@
+
 /* Menu item goes to next line due to float:right issue on Firefox */
 @-moz-document url-prefix() {
     .context-menu .menu-shortcut {
@@ -75,4 +76,36 @@ li.jstree-leaf > a {
 
 .bramble-inspector-highlight {
     background: rgba(0, 135, 207, .3) !important;
+}
+
+/* Right-click File Menu */
+
+.context-menu .dropdown-menu  {
+  padding: 0;
+  border-radius: 0;
+  border: none;
+}
+
+.context-menu .dropdown-menu li a {
+  padding: 10px 12px;
+  line-height: 16px;
+  font-size: 16px;
+  cursor: pointer;
+}
+
+.context-menu .dropdown-menu li a:before {
+  display: none;
+}
+
+.context-menu .dropdown-menu li a:hover {
+  background: rgba(0,0,0,.1);
+}
+
+.dark .context-menu .dropdown-menu li a {
+  color: rgba(255,255,255,.8);
+}
+
+.dark .context-menu .dropdown-menu li a:hover {
+  background: rgba(255,255,255,.1);
+  color: rgba(255,255,255,1);
 }

--- a/src/styles/bramble_overrides.css
+++ b/src/styles/bramble_overrides.css
@@ -1,4 +1,3 @@
-
 /* Menu item goes to next line due to float:right issue on Firefox */
 @-moz-document url-prefix() {
     .context-menu .menu-shortcut {


### PR DESCRIPTION
Updated the spacing, sizing and hover-state of the right-click context menus in the file tree for both dark & light themes.

![menu-styling](https://cloud.githubusercontent.com/assets/25212/22848394/ed747c8c-efa8-11e6-81fc-4876fe97fb8e.gif)
