### PR TITLE
Fix #368: fix for highlight open file on launch

### DIFF
--- a/src/extensions/default/bramble/stylesheets/sidebarTheme.css
+++ b/src/extensions/default/bramble/stylesheets/sidebarTheme.css
@@ -34,12 +34,15 @@ li.jstree-leaf>a>span.extension {
 	color: #666666;
 }
 .filetree-selection {
-	background-color: #333333;
-	border: none;
-	color: white;
+	background-color: rgba(255,255,255,0.2);
+	border: none;   
 	font-weight: bolder;
 	padding: 13px;
 	width: 100% !important;
+	display: block !important;
+}
+.file-test {
+	color:white;
 }
 .filetree-selection-extension {
 	opacity: 0;
@@ -55,7 +58,7 @@ li.jstree-leaf>a>span.extension {
 	font-size: 15px;
 }
 .context {
-	color: rgba(255,255,255,0.6); 
+	color: rgba(255,255,255,0.6);
 }
 li.jstree-leaf>a.jstree-clicked>span {
 	color: white;


### PR DESCRIPTION
@flukeout 
@humphd 
@gideonthomas 

Hey,

Managed to hopefully fix this problem.
<img width="307" alt="screen shot 2017-02-11 at 1 59 27 pm" src="https://cloud.githubusercontent.com/assets/3598286/22857451/3e4c5970-f073-11e6-9e8c-4abed5f8cfdc.png">

Let me know if you have any suggestions or addition, I'm still working on getting the white font.:)