### PR TITLE
Fix padding so it is really 0 on filetree container, to deal with upstream merge changes

### DIFF
--- a/src/extensions/default/bramble/stylesheets/sidebarTheme.css
+++ b/src/extensions/default/bramble/stylesheets/sidebarTheme.css
@@ -28,7 +28,7 @@ div.working-set-option-btn[style] {
 }
 
 #project-files-container ul {
-    padding: 0;
+    padding: 0 !important;
 }
 
 


### PR DESCRIPTION
The merge I just did with upstream seems to have broken the CSS a bit on the filetree container (adding an indent):

![screen shot 2017-02-16 at 2 00 36 pm](https://cloud.githubusercontent.com/assets/427398/23037075/18302ba2-f453-11e6-8f96-31d6680179af.png)

This fixes things as suggested by @flukeout.