### PR TITLE
add support for backend to fix #1633

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,6 +307,7 @@ a number of read-only getters are available in order to access state information
 * `getWordWrap()` - returns the current word wrap setting as a `Boolean` (i.e., enabled or disabled).
 * `getTutorialExists()` - returns `true` or `false` depending on whether or not there is a tutorial in the project (i.e., if `tutorial.html` is present)
 * `getTutorialVisible()` - returns `true` or `false` depending on whether or not the preview browser is showing a tutorial or not.
+* `getAutoUpdate()` - returns `true` or `false` depending on whether or not the auto update preference is enabled or not.
 
 **NOTE**: calling these getters before the `ready()` callback on the bramble instance
 won't do what you want.
@@ -373,6 +374,7 @@ the following events:
 * `"tutorialRemoved"` - triggered when an existing tutorial for the project is removed
 * `"tutorialVisibilityChange"` - triggered when the tutorial preview is turned on or off. It includes an `Object` with a `visibility` property that indicates whether the tutorial is visible.
 * `"inspectorChange"` - triggered whenever the inspector changes from enabled to disabled, or vice versa. It includes an `Object` with an `enabled` property set to `true` or `false`.
+* `"autoUpdateChange"` - triggered whenever the auto update preference changes from enabled to disabled, or vice versa. It includes an `Object` with a `autoUpdate` property set to `true` or `false`
 
 There are also high-level events for changes to files:
 

--- a/src/bramble/client/StateManager.js
+++ b/src/bramble/client/StateManager.js
@@ -105,6 +105,10 @@ define(function() {
             allowJavaScript: {
                 get: function()  { return getBool(storage, "allowJavaScript"); },
                 set: function(v) { storage.setItem(prefix("allowJavaScript"), v); }
+            },
+            autoUpdate: {
+                get: function()  { return getBool(storage, "autoUpdate"); },
+                set: function(v) { storage.setItem(prefix("autoUpdate"), v); }
             }
         });
     }

--- a/src/bramble/client/main.js
+++ b/src/bramble/client/main.js
@@ -205,6 +205,7 @@ define([
         self.getRootDir = function() { return _root; };
         self.getWordWrap = function() { return _state.wordWrap; };
         self.getAllowJavaScript = function() { return _state.allowJavaScript; };
+        self.getAutoUpdate = function() { return _state.autoUpdate; };
         self.getTutorialExists = function() { return _tutorialExists; };
         self.getTutorialVisible = function() { return _tutorialVisible; };
         self.getLayout = function() {
@@ -264,6 +265,7 @@ define([
                     _state.theme = data.theme;
                     _state.wordWrap = data.wordWrap;
                     _state.allowJavaScript = data.allowJavaScript;
+                    _state.autoUpdate = data.autoUpdate;
 
                     setReadyState(Bramble.READY);
                 }
@@ -303,6 +305,8 @@ define([
                         _state.allowJavaScript = data.allowJavaScript;
                     } else if (eventName === "tutorialVisibilityChange") {
                         _tutorialVisible = data.visible;
+                    } else if (eventName === "autoUpdateChange") {
+                        _state.autoUpdate = data.autoUpdate;
                     }
 
                     debug("triggering remote event", eventName, data);
@@ -417,7 +421,8 @@ define([
                                     secondPaneWidth: _state.secondPaneWidth,
                                     previewMode: _state.previewMode,
                                     wordWrap: _state.wordWrap,
-                                    allowJavaScript: _state.allowJavaScript
+                                    allowJavaScript: _state.allowJavaScript,
+                                    autoUpdate: _state.autoUpdate
                                 }
                             };
                             _brambleWindow.postMessage(JSON.stringify(initMessage), _iframe.src);

--- a/src/command/Commands.js
+++ b/src/command/Commands.js
@@ -111,6 +111,7 @@ define(function (require, exports, module) {
     exports.TOGGLE_ACTIVE_LINE          = "view.toggleActiveLine";      // EditorOptionHandlers.js      _getToggler()
     exports.TOGGLE_WORD_WRAP            = "view.toggleWordWrap";        // EditorOptionHandlers.js      _getToggler()
     exports.TOGGLE_ALLOW_JAVASCRIPT     = "cmd.toggleAllowJavaScript";  // EditorOptionsHandlers.js     _getToggler()
+    exports.TOGGLE_AUTO_UPDATE          = "cmd.toggleAutoUpdate";       // EditorOptionsHandlers.js     _getToggler()
 
     exports.CMD_OPEN                        = "cmd.open";
     exports.CMD_ADD_TO_WORKINGSET_AND_OPEN  = "cmd.addToWorkingSetAndOpen";          // DocumentCommandHandlers.js   handleOpenDocumentInNewPane()

--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -96,8 +96,9 @@ define(function (require, exports, module) {
         UPPERCASE_COLORS    = "uppercaseColors",
         USE_TAB_CHAR        = "useTabChar",
         WORD_WRAP           = "wordWrap",
-        INDENT_LINE_COMMENT  = "indentLineComment",
-        ALLOW_JAVASCRIPT    = "allowJavaScript";
+        INDENT_LINE_COMMENT = "indentLineComment",
+        ALLOW_JAVASCRIPT    = "allowJavaScript",
+        AUTO_UPDATE         = "autoUpdate";
     
 
     var cmOptions         = {};
@@ -219,6 +220,10 @@ define(function (require, exports, module) {
 
     PreferencesManager.definePreference(ALLOW_JAVASCRIPT,     "boolean", true, {
         description: Strings.DESCRIPTION_ALLOW_JAVASCRIPT
+    });
+
+    PreferencesManager.definePreference(AUTO_UPDATE,         "boolean", true, {
+        description: Strings.DESCRIPTION_AUTO_UPDATE
     });
 
 

--- a/src/editor/EditorOptionHandlers.js
+++ b/src/editor/EditorOptionHandlers.js
@@ -37,7 +37,8 @@ define(function (require, exports, module) {
         STYLE_ACTIVE_LINE = "styleActiveLine",
         WORD_WRAP         = "wordWrap",
         ALLOW_JAVASCRIPT  = "allowJavaScript",
-        CLOSE_BRACKETS    = "closeBrackets";
+        CLOSE_BRACKETS    = "closeBrackets",
+        AUTO_UPDATE       = "autoUpdate";
 
     /**
      * @private
@@ -50,6 +51,7 @@ define(function (require, exports, module) {
     _optionMapping[WORD_WRAP] = Commands.TOGGLE_WORD_WRAP;
     _optionMapping[ALLOW_JAVASCRIPT] = Commands.TOGGLE_ALLOW_JAVASCRIPT;
     _optionMapping[CLOSE_BRACKETS] = Commands.TOGGLE_CLOSE_BRACKETS;
+    _optionMapping[AUTO_UPDATE] = Commands.TOGGLE_AUTO_UPDATE;
 
     /**
      * @private
@@ -102,6 +104,7 @@ define(function (require, exports, module) {
 
     // XXXBramble
     CommandManager.registerInternal(Commands.TOGGLE_ALLOW_JAVASCRIPT, _getToggler(ALLOW_JAVASCRIPT));
+    CommandManager.registerInternal(Commands.TOGGLE_AUTO_UPDATE, _getToggler(AUTO_UPDATE));
 
     AppInit.htmlReady(_init);
 });

--- a/src/extensions/default/bramble/lib/PostMessageTransport.js
+++ b/src/extensions/default/bramble/lib/PostMessageTransport.js
@@ -16,7 +16,8 @@ define(function (require, exports, module) {
         LiveDevMultiBrowser = brackets.getModule("LiveDevelopment/LiveDevMultiBrowser"),
         BlobUtils           = brackets.getModule("filesystem/impls/filer/BlobUtils"),
         BrambleEvents       = brackets.getModule("bramble/BrambleEvents"),
-        Path                = brackets.getModule("filesystem/impls/filer/BracketsFiler").Path;
+        Path                = brackets.getModule("filesystem/impls/filer/BracketsFiler").Path,
+        BrambleStartupState = brackets.getModule("bramble/StartupState");
 
     // The script that will be injected into the previewed HTML to handle the other side of the post message connection.
     var PostMessageTransportRemote = require("text!lib/PostMessageTransportRemote.js");
@@ -104,6 +105,11 @@ define(function (require, exports, module) {
     */
     function start(){
         window.addEventListener("message", _listener);
+
+        var autoUpdate = BrambleStartupState.ui("autoUpdate");
+        if(typeof autoUpdate === "boolean") {
+            setAutoUpdate(autoUpdate);
+        }
 
         // Reload whenever files are removed or renamed
         BrambleEvents.on("fileRemoved", reload);

--- a/src/extensions/default/bramble/lib/RemoteCommandHandler.js
+++ b/src/extensions/default/bramble/lib/RemoteCommandHandler.js
@@ -84,9 +84,11 @@ define(function (require, exports, module) {
             UI.disableFullscreenPreview();
             break;
         case "BRAMBLE_ENABLE_AUTO_UPDATE":
+            PreferencesManager.set("autoUpdate", true);
             PostMessageTransport.setAutoUpdate(true);
             break;
         case "BRAMBLE_DISABLE_AUTO_UPDATE":
+            PreferencesManager.set("autoUpdate", false);
             PostMessageTransport.setAutoUpdate(false);
             break;
         case "BRAMBLE_ENABLE_SCRIPTS":

--- a/src/extensions/default/bramble/lib/RemoteEvents.js
+++ b/src/extensions/default/bramble/lib/RemoteEvents.js
@@ -133,6 +133,14 @@ define(function (require, exports, module) {
                 allowJavaScript: PreferencesManager.get("allowJavaScript")
             });
         });
+
+        //Listen for changes to auto update
+        PreferencesManager.on("change", "autoUpdate", function () {
+            sendEvent({
+                type: "bramble:autoUpdateChange",
+                autoUpdate: PreferencesManager.get("autoUpdate")
+            });
+        });
     }
 
     /**
@@ -165,7 +173,8 @@ define(function (require, exports, module) {
             fontSize: ViewCommandHandlers.getFontSize(),
             theme: Theme.getTheme(),
             wordWrap: PreferencesManager.get("wordWrap"),
-            allowJavaScript: PreferencesManager.get("allowJavaScript")
+            allowJavaScript: PreferencesManager.get("allowJavaScript"),
+            autoUpdate: PreferencesManager.get("autoUpdate")
         });
     }
 

--- a/src/extensions/default/bramble/lib/UI.js
+++ b/src/extensions/default/bramble/lib/UI.js
@@ -95,6 +95,11 @@ define(function (require, exports, module) {
             PreferencesManager.set("allowJavaScript", allowJavaScript);
         }
 
+        var autoUpdate = BrambleStartupState.ui("autoUpdate");
+        if(typeof autoUpdate === "boolean") {
+            PreferencesManager.set("autoUpdate", autoUpdate);
+        }
+
         var sidebarWidth = BrambleStartupState.ui("sidebarWidth");
         if(sidebarWidth) {
             SidebarView.resize(sidebarWidth);

--- a/src/extensions/default/bramble/main.js
+++ b/src/extensions/default/bramble/main.js
@@ -191,7 +191,8 @@ define(function (require, exports, module) {
             secondPaneWidth: data.state.secondPaneWidth,
             previewMode: data.state.previewMode,
             wordWrap: data.state.wordWrap,
-            allowJavaScript: data.state.allowJavaScript
+            allowJavaScript: data.state.allowJavaScript,
+            autoUpdate: data.state.autoUpdate
         });
 
         RemoteEvents.start();


### PR DESCRIPTION
This is a work in progress for #1633 for the bramble side of the fix. 
The fix will create a preference for the auto update setting so that if a user refreshes their browser, the setting will persist.