### PR TITLE
Automatically run unlocalize task when done building dist/ to restore src/nls/*

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -632,6 +632,7 @@ module.exports = function (grunt) {
         /* XXXBramble: we skip this, since we don't use any of the node_modules in Bramble.
          'npm-install', */
         'cleanempty',
+        'exec:clean-nls',
         'usemin',
         'build-config'
     ]);


### PR DESCRIPTION
I'm seeing so many of my students get stumped by the fact that we touch files in `src/nls/*` and don't know how to restore them.  I can't believe I didn't think of this before, but we should just be undoing it as soon as we're done.