### PR TITLE
Fix https://github.com/mozilla/thimble.mozilla.org/issues/1762

### DIFF
--- a/src/extensions/default/bramble/nohost/HTMLServer.js
+++ b/src/extensions/default/bramble/nohost/HTMLServer.js
@@ -108,6 +108,15 @@ define(function (require, exports, module) {
         var liveDocument = this.get(path);
 
         function serveCSS(path, css, callback) {
+            // If we already have a cached Blob URL for this path, use it,
+            // otherwise generate a new one. This can happen if a file is included
+            // more than once in the same HTML file (e.g., multiple <link>s with same `src`).
+            var existingURL = BlobUtils.getUrl(path);
+            if(existingURL !== path) {
+                callback(null, existingURL);
+                return;
+            }
+
             CSSRewriter.rewrite(path, css, function(err, css) {
                 if(err) {
                     callback(err);


### PR DESCRIPTION
This is a really subtle bug.  To trigger it, you have to include the same CSS file more than once in the same HTML file.  Right now we're rewriting it for each inclusion, which has the side effect of deleting the previous `blob:` URL from our cache.

This reuses a given CSS URL from the cache.