### PR TITLE
Modified Upload, checks is dialog already exists, fixes https://github.com/mozilla/thimble.mozilla.org/issues/1779

### DIFF
--- a/src/extensions/default/UploadFiles/UploadFilesDialog.js
+++ b/src/extensions/default/UploadFiles/UploadFilesDialog.js
@@ -4,6 +4,8 @@
 define(function (require, exports, module) {
     "use strict";
 
+    var _uploadDialog = null;
+
     var StartupState   = brackets.getModule("bramble/StartupState");
     var Path           = brackets.getModule("filesystem/impls/filer/BracketsFiler").Path;
     var CommandManager = brackets.getModule("command/CommandManager");
@@ -164,13 +166,17 @@ define(function (require, exports, module) {
         Dialogs.cancelModalDialogIfOpen("upload-files-dialog");
     };
     FileUploadDialog.prototype.destroy = function() {
+        _uploadDialog = null;
         this.fileInput.remove();
     };
 
-
     function show() {
-        var uploadDialog = new FileUploadDialog();
-        return uploadDialog.show();
+        if(_uploadDialog) {
+           return _uploadDialog.deferred.promise();
+        }
+
+        _uploadDialog = new FileUploadDialog();
+        return _uploadDialog.show();
     }
 
     exports.show = show;


### PR DESCRIPTION
Added jQuery to see if there is upload dialog already open, if it does do nothing else call the `.show()` function.
Fixes issue [#1779](https://github.com/mozilla/thimble.mozilla.org/issues/1779)
![issue 1779](https://cloud.githubusercontent.com/assets/11877279/23576525/e25dee54-0075-11e7-962e-fad68e363e21.gif)

