### PR TITLE
Fix #491: Zip and tar files upload size limit

### DIFF
--- a/locales/en-US/editor.properties
+++ b/locales/en-US/editor.properties
@@ -126,7 +126,6 @@ CMD_TOGGLE_QUICK_DOCS=Quick Docs
 
 # Drag and Drop
 
-DND_MAX_SIZE_EXCEEDED=file exceeds maximum supported size: {0} MB.
 DND_UNSUPPORTED_FILE_TYPE=unsupported file type
 DND_ERROR_UNZIP=unable to unzip file
 DND_ERROR_UNTAR=unable to untar file

--- a/src/filesystem/impls/filer/FilerUtils.js
+++ b/src/filesystem/impls/filer/FilerUtils.js
@@ -22,4 +22,11 @@ define(function (require, exports, module) {
             return path;
         }
     };
+
+    // Normalize '.html', 'html', '.HTML', 'HTML' all to '.html', unless exludePeriod is 'true'
+    // then make it just 'html' without the period.
+    exports.normalizeExtension = function(ext, exludePeriod) {
+        var maybePeriod = exludePeriod ? "" : ".";
+        return maybePeriod + ext.replace(/^\./, "").toLowerCase();
+    };
 });

--- a/src/filesystem/impls/filer/FilerUtils.js
+++ b/src/filesystem/impls/filer/FilerUtils.js
@@ -25,8 +25,8 @@ define(function (require, exports, module) {
 
     // Normalize '.html', 'html', '.HTML', 'HTML' all to '.html', unless exludePeriod is 'true'
     // then make it just 'html' without the period.
-    exports.normalizeExtension = function(ext, exludePeriod) {
-        var maybePeriod = exludePeriod ? "" : ".";
+    exports.normalizeExtension = function(ext, excludePeriod) {
+        var maybePeriod = excludePeriod ? "" : ".";
         return maybePeriod + ext.replace(/^\./, "").toLowerCase();
     };
 });

--- a/src/filesystem/impls/filer/lib/content.js
+++ b/src/filesystem/impls/filer/lib/content.js
@@ -44,7 +44,7 @@ define(function (require, exports, module) {
         },
 
         mimeFromExt: function(ext) {
-            ext = FilerUtils.normalizeExtension(ext, false);
+            ext = FilerUtils.normalizeExtension(ext);
 
             switch(ext) {
             case '.html':

--- a/src/filesystem/impls/filer/lib/content.js
+++ b/src/filesystem/impls/filer/lib/content.js
@@ -38,7 +38,7 @@ define(function (require, exports, module) {
         },
 
         isArchive: function(ext) {
-            if (ext == "zip" || ext == "tar") {
+            if (ext === "zip" || ext === "tar") {
                 return true;
             } else {
                 return false;

--- a/src/filesystem/impls/filer/lib/content.js
+++ b/src/filesystem/impls/filer/lib/content.js
@@ -44,7 +44,7 @@ define(function (require, exports, module) {
         },
 
         mimeFromExt: function(ext) {
-            ext = FilerUtils.normalizeExtension(false);
+            ext = FilerUtils.normalizeExtension(ext, false);
 
             switch(ext) {
             case '.html':

--- a/src/filesystem/impls/filer/lib/content.js
+++ b/src/filesystem/impls/filer/lib/content.js
@@ -5,9 +5,10 @@ define(function (require, exports, module) {
     "use strict";
 
     var LanguageManager = require('language/LanguageManager');
+    var FilerUtils = require('filesystem/impls/filer/FilerUtils');
 
     function _getLanguageId(ext) {
-        ext = ext.replace(/^\./, "").toLowerCase();
+        ext = FilerUtils.normalizeExtension(ext, true);
         var language = LanguageManager.getLanguageForExtension(ext);
         return language ? language.getId() : "";
     }
@@ -38,15 +39,12 @@ define(function (require, exports, module) {
         },
 
         isArchive: function(ext) {
-            if (ext === "zip" || ext === "tar") {
-                return true;
-            } else {
-                return false;
-            }
+            ext = FilerUtils.normalizeExtension(ext);
+            return ext === '.zip' || ext === '.tar'; 
         },
 
         mimeFromExt: function(ext) {
-            ext = ext.toLowerCase();
+            ext = FilerUtils.normalizeExtension(false);
 
             switch(ext) {
             case '.html':

--- a/src/filesystem/impls/filer/lib/content.js
+++ b/src/filesystem/impls/filer/lib/content.js
@@ -37,6 +37,14 @@ define(function (require, exports, module) {
             return id === "markdown";
         },
 
+        isArchive: function(ext) {
+            if (ext == "zip" || ext == "tar") {
+                return true;
+            } else {
+                return false;
+            }
+        },
+
         mimeFromExt: function(ext) {
             ext = ext.toLowerCase();
 

--- a/src/utils/DragAndDrop.js
+++ b/src/utils/DragAndDrop.js
@@ -336,7 +336,7 @@ define(function (require, exports, module) {
          * or not a mime type we care about, reject it.
          */
         function rejectImport(item) {
-            var ext = FilerUtils.normalizeExtension(Path.extname(item.name), true);
+            var ext = Path.extname(item.name);
             var sizeLimit = Content.isArchive(ext) ? archiveByteLimit : byteLimit;
             var sizeLimitMb = (sizeLimit / (1024 * 1024)).toString();
 

--- a/src/utils/DragAndDrop.js
+++ b/src/utils/DragAndDrop.js
@@ -337,15 +337,12 @@ define(function (require, exports, module) {
          */
         function rejectImport(item) {
             var ext = FilerUtils.normalizeExtension(Path.extname(item.name), true);
+            var sizeLimit = Content.isArchive(ext) ? archiveByteLimit : byteLimit;
+            var sizeLimitMb = (sizeLimit / (1024 * 1024)).toString();
 
-            if (item.size > archiveByteLimit) {
-                return new Error(StringUtils.format(Strings.DND_MAX_SIZE_EXCEEDED, "5"));
-
-            } else if (item.size > byteLimit) {
-                if(!Content.isArchive(ext)){
-                    return new Error(StringUtils.format(Strings.DND_MAX_SIZE_EXCEEDED, "3"));
-                }
-            }
+            if (item.size > sizeLimit) {
+                return new Error(StringUtils.format(Strings.DND_MAX_SIZE_EXCEEDED, sizeLimitMb));
+            } 
 
             // If we don't know about this language type, or the OS doesn't think
             // it's text, reject it.

--- a/src/utils/DragAndDrop.js
+++ b/src/utils/DragAndDrop.js
@@ -47,7 +47,8 @@ define(function (require, exports, module) {
         Content         = require("filesystem/impls/filer/lib/content"),
         LanguageManager = require("language/LanguageManager"),
         StartupState    = require("bramble/StartupState"),
-        ArchiveUtils    = require("filesystem/impls/filer/ArchiveUtils");
+        ArchiveUtils    = require("filesystem/impls/filer/ArchiveUtils"),
+        FilerUtils = require('filesystem/impls/filer/FilerUtils');
 
     // 3MB size limit for imported files. If you change this, also change the
     // error message we generate in rejectImport() below!
@@ -335,7 +336,7 @@ define(function (require, exports, module) {
          * or not a mime type we care about, reject it.
          */
         function rejectImport(item) {
-            var ext = Content.FilerUtils.normalizeExtension(Path.extname(item.name), true);
+            var ext = FilerUtils.normalizeExtension(Path.extname(item.name), true);
             
             if (item.size > archiveByteLimit) {
                 return new Error(Strings.DND_MAX_FILE_SIZE_EXCEEDED);

--- a/src/utils/DragAndDrop.js
+++ b/src/utils/DragAndDrop.js
@@ -336,10 +336,11 @@ define(function (require, exports, module) {
          */
         function rejectImport(item) {
             var ext = Path.extname(item.name).replace(/^\./, "").toLowerCase();
+            
             if (item.size > archiveByteLimit) {
                 return new Error(Strings.DND_MAX_FILE_SIZE_EXCEEDED);
             } else if (item.size > byteLimit) {
-                if (ext !== "zip" && ext !== "tar") {
+                if(!Content.isArchive(ext)){
                     return new Error(Strings.DND_MAX_FILE_SIZE_EXCEEDED);
                 }
             }

--- a/src/utils/DragAndDrop.js
+++ b/src/utils/DragAndDrop.js
@@ -53,6 +53,9 @@ define(function (require, exports, module) {
     // error message we generate in rejectImport() below!
     var byteLimit = 3145728;
 
+    // 5MB size limit for imported archives (zip & tar)
+    var archiveByteLimit = 5242880;
+
     /**
      * Returns true if the drag and drop items contains valid drop objects.
      * @param {Array.<DataTransferItem>} items Array of items being dragged
@@ -332,13 +335,21 @@ define(function (require, exports, module) {
          * or not a mime type we care about, reject it.
          */
         function rejectImport(item) {
-            if (item.size > byteLimit) {
+            var ext = Path.extname(item.name).replace(/^\./, "").toLowerCase();
+            if (item.size > archiveByteLimit) {
                 return new Error(Strings.DND_MAX_FILE_SIZE_EXCEEDED);
+            } 
+            else if (item.size > byteLimit) {
+                if (ext !== "zip" && ext !== "tar") {
+                    return new Error(Strings.DND_MAX_FILE_SIZE_EXCEEDED);
+                }
             }
+
+            
 
             // If we don't know about this language type, or the OS doesn't think
             // it's text, reject it.
-            var ext = Path.extname(item.name).replace(/^\./, "").toLowerCase();
+            //var ext = Path.extname(item.name).replace(/^\./, "").toLowerCase();
             var languageIsSupported = !!LanguageManager.getLanguageForExtension(ext);
             var typeIsText = Content.isTextType(item.type);
 

--- a/src/utils/DragAndDrop.js
+++ b/src/utils/DragAndDrop.js
@@ -335,7 +335,7 @@ define(function (require, exports, module) {
          * or not a mime type we care about, reject it.
          */
         function rejectImport(item) {
-            var ext = Path.extname(item.name).replace(/^\./, "").toLowerCase();
+            var ext = Content.FilerUtils.normalizeExtension(Path.extname(item.name), true);
             
             if (item.size > archiveByteLimit) {
                 return new Error(Strings.DND_MAX_FILE_SIZE_EXCEEDED);
@@ -408,7 +408,7 @@ define(function (require, exports, module) {
 
                 var filename = Path.join(StartupState.project("root"), item.name);
                 var file = FileSystem.getFileForPath(filename);
-                var ext = Path.extname(filename).toLowerCase();
+                var ext = Path.extname(filename);
 
                 // Create a Filer Buffer, and determine the proper encoding. We
                 // use the extension, and also the OS provided mime type for clues.

--- a/src/utils/DragAndDrop.js
+++ b/src/utils/DragAndDrop.js
@@ -48,7 +48,7 @@ define(function (require, exports, module) {
         LanguageManager = require("language/LanguageManager"),
         StartupState    = require("bramble/StartupState"),
         ArchiveUtils    = require("filesystem/impls/filer/ArchiveUtils"),
-        FilerUtils = require('filesystem/impls/filer/FilerUtils');
+        FilerUtils      = require('filesystem/impls/filer/FilerUtils');
 
     // 3MB size limit for imported files. If you change this, also change the
     // error message we generate in rejectImport() below!
@@ -337,12 +337,13 @@ define(function (require, exports, module) {
          */
         function rejectImport(item) {
             var ext = FilerUtils.normalizeExtension(Path.extname(item.name), true);
-            
+
             if (item.size > archiveByteLimit) {
-                return new Error(Strings.DND_MAX_ARCHIVE_SIZE_EXCEEDED);
+                return new Error(StringUtils.format(Strings.DND_MAX_SIZE_EXCEEDED, "5"));
+
             } else if (item.size > byteLimit) {
                 if(!Content.isArchive(ext)){
-                    return new Error(Strings.DND_MAX_FILE_SIZE_EXCEEDED);
+                    return new Error(StringUtils.format(Strings.DND_MAX_SIZE_EXCEEDED, "3"));
                 }
             }
 

--- a/src/utils/DragAndDrop.js
+++ b/src/utils/DragAndDrop.js
@@ -339,7 +339,7 @@ define(function (require, exports, module) {
             var ext = FilerUtils.normalizeExtension(Path.extname(item.name), true);
             
             if (item.size > archiveByteLimit) {
-                return new Error(Strings.DND_MAX_FILE_SIZE_EXCEEDED);
+                return new Error(Strings.DND_MAX_ARCHIVE_SIZE_EXCEEDED);
             } else if (item.size > byteLimit) {
                 if(!Content.isArchive(ext)){
                     return new Error(Strings.DND_MAX_FILE_SIZE_EXCEEDED);

--- a/src/utils/DragAndDrop.js
+++ b/src/utils/DragAndDrop.js
@@ -338,18 +338,14 @@ define(function (require, exports, module) {
             var ext = Path.extname(item.name).replace(/^\./, "").toLowerCase();
             if (item.size > archiveByteLimit) {
                 return new Error(Strings.DND_MAX_FILE_SIZE_EXCEEDED);
-            } 
-            else if (item.size > byteLimit) {
+            } else if (item.size > byteLimit) {
                 if (ext !== "zip" && ext !== "tar") {
                     return new Error(Strings.DND_MAX_FILE_SIZE_EXCEEDED);
                 }
             }
 
-            
-
             // If we don't know about this language type, or the OS doesn't think
             // it's text, reject it.
-            //var ext = Path.extname(item.name).replace(/^\./, "").toLowerCase();
             var languageIsSupported = !!LanguageManager.getLanguageForExtension(ext);
             var typeIsText = Content.isTextType(item.type);
 


### PR DESCRIPTION
Hello, here is the link to the issue itself: https://github.com/mozilla/brackets/issues/491
I changed the rejectImport function (https://github.com/mozilla/brackets/blob/master/src/utils/DragAndDrop.js#L330-L349), so it's allowing to import tar and zip files up to 5MB. Note that maximum size for these extensions can be easily changed. So for example, we can change it to 10MB ( since the size is a variable, like the byteLimit for all other files).
here is a gif image to represent the fix:
![bug](https://cloud.githubusercontent.com/assets/15698572/23688307/c883b31a-0381-11e7-9d20-7867d2b4c288.gif)

Here is a gif image representing that we can't upload any kind of file that is bigger that 5MB:
![bug_with_error](https://cloud.githubusercontent.com/assets/15698572/23688391/597326bc-0382-11e7-8224-0a628457846c.gif)

Here is a gif image representing that we can't upload any kind of file bigger that 3MB (beside zip or tar):
![bug_test](https://cloud.githubusercontent.com/assets/15698572/23713528/35e54f5a-03f4-11e7-868b-913bdc4d2898.gif)

While I was doing this bug, I also noticed issue 1 and issue 2. Issue 1 I’ve filed in #1833 (https://github.com/mozilla/thimble.mozilla.org/issues/1833). However issue 2 is caused by my code. 
![bug_with_error](https://cloud.githubusercontent.com/assets/15698572/23716099/fae61552-03fc-11e7-9e5c-b1a07a4733ca.gif)

Basically, the bug is in the error message. For files that are not zip or tar, the max size is 3MB, therefore, the error message for them is correct. However, for tar and zip files, the max size is now 5MB, but the message tells is't 3MB. 

I am going to create an issue on this bug, if my pull request will be accepted, otherwise, this issue does not exist. 
