### PR TITLE
Streamline how we build CodeMirror in dist/ so things get bundled, part of #634

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -166,6 +166,18 @@ module.exports = function (grunt) {
                 files: [
                     {
                         expand: true,
+                        dest: 'src/thirdparty/CodeMirror',
+                        cwd: 'src/node_modules/codemirror',
+                        src: [
+                            'addon/{,*/}*',
+                            'keymap/{,*/}*',
+                            'lib/{,*/}*',
+                            'mode/{,*/}*',
+                            'theme/{,*/}*',
+                        ]
+                    },
+                    {
+                        expand: true,
                         flatten: true,
                         dest: 'src/thirdparty',
                         cwd: 'src/node_modules',

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -161,6 +161,19 @@ module.exports = function (grunt) {
                         src: ['jsTreeTheme.css', 'fonts/{,*/}*.*', 'images/*', 'brackets.min.css*', 'bramble_overrides.css']
                     }
                 ]
+            },
+            thirdparty: {
+                files: [
+                    {
+                        expand: true,
+                        flatten: true,
+                        dest: 'src/thirdparty',
+                        cwd: 'src/node_modules',
+                        src: [
+                            'less/dist/less.min.js'
+                        ]
+                    }
+                ]
             }
         },
         cleanempty: {

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -76,7 +76,6 @@ module.exports = function (grunt) {
                         /* static files */
                         'xorigin.js',
                         'dependencies.js',
-                        'thirdparty/requirejs/require.js',
 
                         /* extensions and CodeMirror modes */
                         '!extensions/default/*/unittests.js',
@@ -86,12 +85,6 @@ module.exports = function (grunt) {
                         '!extensions/**/node_modules/**/*.js',
                         '!extensions/**/test/**/*.js',
                         '!**/unittest-files/**',
-                        'thirdparty/CodeMirror/addon/{,*/}*.js',
-                        'thirdparty/CodeMirror/keymap/{,*/}*.js',
-                        'thirdparty/CodeMirror/lib/{,*/}*.js',
-                        'thirdparty/CodeMirror/mode/{,*/}*.js',
-                        'thirdparty/CodeMirror/theme/{,*/}*.js',
-                        'thirdparty/slowparse/slowparse.js',
                         'thirdparty/i18n/*.js',
                         'thirdparty/text/*.js'
                     ],
@@ -122,10 +115,7 @@ module.exports = function (grunt) {
                             'nls/{,*/}*.js',
                             'xorigin.js',
                             'dependencies.js',
-                            'thirdparty/requirejs/require.js',
-                            'thirdparty/slowparse/locale/*',
                             'thirdparty/github-markdown.css',
-                            'LiveDevelopment/launch.html',
                             'hosted.*',
                             // XXXBramble: we don't use src/config.json like Brackets does,
                             // but it needs to exist in dist/ so copy it
@@ -158,13 +148,7 @@ module.exports = function (grunt) {
                             '!extensions/extra/*/thirdparty/**/*.htm{,l}',
                             '!extensions/dev/*',
                             '!extensions/samples/**/*',
-                            'thirdparty/CodeMirror/addon/{,*/}*',
-                            'thirdparty/CodeMirror/keymap/{,*/}*',
-                            'thirdparty/CodeMirror/lib/{,*/}*',
-                            'thirdparty/CodeMirror/mode/{,*/}*',
-                            '!thirdparty/CodeMirror/mode/**/*.html',
-                            '!thirdparty/CodeMirror/**/*test.js',
-                            'thirdparty/CodeMirror/theme/{,*/}*',
+                            'thirdparty/CodeMirror/lib/codemirror.css',
                             'thirdparty/i18n/*.js',
                             'thirdparty/text/*.js'
                         ]
@@ -175,31 +159,6 @@ module.exports = function (grunt) {
                         dest: 'dist/styles',
                         cwd: 'src/styles',
                         src: ['jsTreeTheme.css', 'fonts/{,*/}*.*', 'images/*', 'brackets.min.css*', 'bramble_overrides.css']
-                    }
-                ]
-            },
-            thirdparty: {
-                files: [
-                    {
-                        expand: true,
-                        dest: 'src/thirdparty/CodeMirror',
-                        cwd: 'src/node_modules/codemirror',
-                        src: [
-                            'addon/{,*/}*',
-                            'keymap/{,*/}*',
-                            'lib/{,*/}*',
-                            'mode/{,*/}*',
-                            'theme/{,*/}*',
-                        ]
-                    },
-                    {
-                        expand: true,
-                        flatten: true,
-                        dest: 'src/thirdparty',
-                        cwd: 'src/node_modules',
-                        src: [
-                            'less/dist/less.min.js'
-                        ]
                     }
                 ]
             }

--- a/src/brackets.js
+++ b/src/brackets.js
@@ -57,6 +57,22 @@ define(function (require, exports, module) {
     require("thirdparty/CodeMirror/addon/selection/mark-selection");
     require("thirdparty/CodeMirror/keymap/sublime");
 
+    // XXXBramble: because we include code folding by default, bundle those addons
+    // so they get bundled with our dist/thirdparty.js file.
+    // See src/extensions/default/CodeFolding/main.js
+    require("thirdparty/CodeMirror/addon/fold/brace-fold");
+    require("thirdparty/CodeMirror/addon/fold/comment-fold");
+    require("thirdparty/CodeMirror/addon/fold/markdown-fold");
+    // XXXBramble: also preload the modes we'll need later, and have them get bundled.
+    // See src/language/LanguageManager.js and src/language/languages.json
+    require("thirdparty/CodeMirror/mode/meta");
+    require("thirdparty/CodeMirror/mode/css/css");
+    require("thirdparty/CodeMirror/mode/htmlmixed/htmlmixed");
+    require("thirdparty/CodeMirror/mode/javascript/javascript");
+    require("thirdparty/CodeMirror/mode/jsx/jsx");
+    require("thirdparty/CodeMirror/mode/xml/xml");
+    require("thirdparty/CodeMirror/mode/markdown/markdown");
+
     // Load dependent modules
     var AppInit             = require("utils/AppInit"),
         LanguageManager     = require("language/LanguageManager"),


### PR DESCRIPTION
This cleans up how we do CodeMirror in `dist/` so that everything gets pre-bundled in our main requirejs bundle.  The only thing we then need to have in `dist/` is a CSS file.