### PR TITLE
Use requirejs to bundle/minify extensions, copy only what we need to dist/, part of #634

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -421,20 +421,19 @@ module.exports = function (grunt) {
 
         // Write a requirejs config for each included extension
         extensions.forEach(function(extension) {
-            config.requirejs[extension] = {
+            config.requirejs[extension.path] = {
                 options: {
-                    name: '../../../thirdparty/almond',
-                    baseUrl: 'src/' + extension,
+                    name: 'main',
+                    baseUrl: 'src/' + extension.path,
                     paths: {
                         'text' : '../../../thirdparty/text/text',
                         'i18n' : '../../../thirdparty/i18n/i18n'
                     },
                     optimize: 'uglify2',
                     preserveLicenseComments: false,
-                    useString: true,
+                    useStrict: true,
                     uglify2: {},
-                    include: ['main.js'],
-                    out: 'dist/' + extension + '/main.js'
+                    out: 'dist/' + extension.path + '/main.js'
                 }
             };
         });
@@ -442,21 +441,13 @@ module.exports = function (grunt) {
         // Also copy each extension's files across to dist/
         var extensionGlobs = [];
         extensions.forEach(function(extension) {
-            // Copy the extension's folder and files over to dist/
-            extensionGlobs.push(extension + "/**");
+            // First, copy the dir itself.  The main.js will get built below.
+            extensionGlobs.push(extension.path.replace(/\/?$/, "/"));
 
-            // with the following exceptions...
-
-            // No .js, .js, or .md files.  The main.js will get made by requirejs
-            extensionGlobs.push('!' + extension + '/**/{*.js,*.json,*.md}');
-            // No unittest-files/*
-            extensionGlobs.push('!' + extension + '/unittest-files/**');
-            // No node_modules/*
-            extensionGlobs.push('!' + extension + '/node_modules/**');
-            // No jquery-ui/* which is used in some tests (and is huge)
-            extensionGlobs.push('!' + extension + '/**/jquery-ui/**');
-            // No LICENSE files
-            extensionGlobs.push('!' + extension + '/**/LICENSE');
+            // If there are any globs defined for extra paths to copy, add those too.
+            if(extension.copy) {
+                extensionGlobs = extensionGlobs.concat(extension.copy);
+            }
         });
 
         config.copy.dist.files.push({
@@ -468,7 +459,7 @@ module.exports = function (grunt) {
 
         // Add a task for building all requirejs bundles for each extension
         var tasks = extensions.map(function(extension) {
-            return 'requirejs:' + extension;
+            return 'requirejs:' + extension.path;
         });
         grunt.registerTask('build-extensions', tasks);
 

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -134,12 +134,12 @@ module.exports = function (grunt) {
                             'thirdparty/text/*.js'
                         ]
                     },
-                    /* styles, fonts and images */
+                    /* styles, fonts and images - XXXBramble: we skip the fonts */
                     {
                         expand: true,
                         dest: 'dist/styles',
                         cwd: 'src/styles',
-                        src: ['jsTreeTheme.css', 'fonts/{,*/}*.*', 'images/*', 'brackets.min.css*', 'bramble_overrides.css']
+                        src: ['jsTreeTheme.css', 'images/*', 'brackets.min.css*', 'bramble_overrides.css']
                     }
                 ]
             },

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -538,7 +538,7 @@ module.exports = function (grunt) {
     grunt.registerTask('build-browser-compressed', [
         'build-browser',
         'compress',
-        //'swPrecache'
+        'swPrecache'
     ]);
 
     // task: undo changes to the src/nls directory

--- a/README.md
+++ b/README.md
@@ -72,53 +72,11 @@ should host Bramble's iframe, see `src/hosted.js`.
 
 **NOTE 3:** To use Bramble in a production setting locally, you can run `npm run production` and access Bramble at [http://localhost:8000/dist](http://localhost:8000/dist)
 
-# Optional Extension Loading
+# Extension Loading
 
-Bramble supports enabling and disabling various extensions via the URL and query params.
-A standard set of default extensions are always turned on:
-
-* CSSCodeHints
-* HTMLCodeHints
-* JavaScriptCodeHints
-* InlineColorEditor
-* JavaScriptQuickEdit
-* QuickOpenCSS
-* QuickOpenHTML
-* QuickOpenJavaScript
-* QuickView
-* UrlCodeHints
-* brackets-paste-and-indent
-* BrambleUrlCodeHints
-* Autosave
-* UploadFiles
-* WebPlatformDocs
-* CodeFolding
-* bramble-move-file
-
-You could disable QuickView and CSSCodeHints by loading Bramble with `?disableExtensions=QuickView,CSSCodeHints`
-on the URL.
-
-In addition, you can enable other extra extensions:
-
-* SVGCodeHints
-* HtmlEntityCodeHints
-* LESSSupport
-* CloseOthers
-* InlineTimingFunctionEditor
-* JSLint
-* QuickOpenCSS
-* RecentProjects
-* brackets-cdn-suggestions
-* HTMLHinter
-* MdnDocs
-* SVGasXML
-
-You could enable JSLint and LESSSupport by loading Bramble with `?enableExtensions=JSLint,LESSSupport`
-on the URL
-
-NOTE: you can combine `disableExtensions` and `enableExtensions` to mix loading/disabling extensions.
-You should check src/utils/BrambleExtensionLoader.js for the most up-to-date version of these
-extension lists.
+Bramble loads a set of extensions defined in `src/extensions/bramble-extensions.json`. You can
+add remove from this list.  You can also temporarily disable extensions by using `?disableExtensions`.
+For example, to disable QuickView and CSSCodeHints load Bramble with `?disableExtensions=QuickView,CSSCodeHints` on the URL.
 
 --------------
 

--- a/src/extensions/README.md
+++ b/src/extensions/README.md
@@ -1,8 +1,8 @@
 # Bramble Extension Loading
 
 Bramble extension loading is done by specifying extensions to be loaded in
-`src/extensions/bramble-extensions.json`.  This is an array of objects with
-the following form:
+[`src/extensions/bramble-extensions.json`](src/extensions/bramble-extensions.json).
+This is an array of objects with the following form:
 
 ```
 {

--- a/src/extensions/README.md
+++ b/src/extensions/README.md
@@ -1,0 +1,23 @@
+# Bramble Extension Loading
+
+Bramble extension loading is done by specifying extensions to be loaded in
+`src/extensions/bramble-extensions.json`.  This is an array of objects with
+the following form:
+
+```
+{
+        "path": "extensions/default/InlineColorEditor",
+        "copy": [
+            "extensions/default/InlineColorEditor/css/main.css",
+            "extensions/default/InlineColorEditor/img/*.png"
+        ]
+}
+```
+
+Here `path` refers to the path under `src/` where the extension's dir lives.
+The optional `copy` array includes file path globs to be used when copying
+files from `src/` to `dist/` for this extension at build time.  Many extensions
+have no external dependencies, other than the `main.js` file and any modules it
+loads.  If this is the case, you don't need to include `copy`.  It will typically
+include things like stylesheets, images, and other resources that get loaded
+dynamically at runtime and aren't packaged using requirejs.

--- a/src/extensions/bramble-extensions.json
+++ b/src/extensions/bramble-extensions.json
@@ -1,0 +1,18 @@
+[
+    "extensions/default/CSSCodeHints",
+    "extensions/default/HTMLCodeHints",
+    "extensions/default/HtmlEntityCodeHints",
+    "extensions/default/JavaScriptCodeHints",
+    "extensions/default/InlineColorEditor",
+    "extensions/default/InlineTimingFunctionEditor",
+    "extensions/default/JavaScriptQuickEdit",
+    "extensions/default/QuickView",
+    "extensions/default/WebPlatformDocs",
+    "extensions/default/CodeFolding",
+    "extensions/default/bramble",
+    "extensions/default/Autosave",
+    "extensions/default/brackets-paste-and-indent",
+    "extensions/default/BrambleUrlCodeHints",
+    "extensions/default/UploadFiles",
+    "extensions/default/bramble-move-file"
+]

--- a/src/extensions/bramble-extensions.json
+++ b/src/extensions/bramble-extensions.json
@@ -1,18 +1,106 @@
 [
-    "extensions/default/CSSCodeHints",
-    "extensions/default/HTMLCodeHints",
-    "extensions/default/HtmlEntityCodeHints",
-    "extensions/default/JavaScriptCodeHints",
-    "extensions/default/InlineColorEditor",
-    "extensions/default/InlineTimingFunctionEditor",
-    "extensions/default/JavaScriptQuickEdit",
-    "extensions/default/QuickView",
-    "extensions/default/WebPlatformDocs",
-    "extensions/default/bramble",
-    "extensions/default/Autosave",
-    "extensions/default/brackets-paste-and-indent",
-    "extensions/default/BrambleUrlCodeHints",
-    "extensions/default/UploadFiles",
-    "extensions/default/bramble-move-file",
-    "extensions/default/brackets-show-whitespace"
+    {
+        "path": "extensions/default/CSSCodeHints",
+        "copy": [
+            "extensions/default/CSSCodeHints/styles/brackets-css-hints.css"
+        ]
+    },
+    {
+        "path": "extensions/default/HTMLCodeHints"
+    },
+    {
+        "path": "extensions/default/HtmlEntityCodeHints",
+        "copy": [
+            "extensions/default/HTMLEntityCodeHints/styles.css"
+        ]
+    },
+    {
+        "path": "extensions/default/JavaScriptCodeHints",
+        "copy": [
+            "extensions/default/JavaScriptCodeHints/node_modules/tern/lib/tern.js",
+            "extensions/default/JavaScriptCodeHints/node_modules/tern/lib/infer.js",
+            "extensions/default/JavaScriptCodeHints/node_modules/tern/lib/def.js",
+            "extensions/default/JavaScriptCodeHints/node_modules/tern/lib/signal.js",
+            "extensions/default/JavaScriptCodeHints/node_modules/tern/defs/ecmascript.json",
+            "extensions/default/JavaScriptCodeHints/node_modules/tern/defs/browser.json",
+            "extensions/default/JavaScriptCodeHints/node_modules/acorn/dist/acorn.js",
+            "extensions/default/JavaScriptCodeHints/node_modules/acorn/dist/acorn_loose.js",
+            "extensions/default/JavaScriptCodeHints/node_modules/acorn/dist/walk.js",
+            "extensions/default/JavaScriptCodeHints/styles/brackets-js-hints.css",
+            "extensions/default/JavaScriptCodeHints/tern-worker.js",
+            "extensions/default/JavaScriptCodeHints/MessageIds.js",
+            "extensions/default/JavaScriptCodeHints/HintUtils2.js"
+        ]
+    },
+    {
+        "path": "extensions/default/InlineColorEditor",
+        "copy": [
+            "extensions/default/InlineColorEditor/css/main.css",
+            "extensions/default/InlineColorEditor/img/*.png"
+        ]
+    },
+    {
+        "path": "extensions/default/InlineTimingFunctionEditor",
+        "copy": [
+            "extensions/default/InlineTimingFunctionEditor/main.css",
+            "extensions/default/InlineTimingFunctionEditor/*.png"
+        ]
+    },
+    {
+        "path": "extensions/default/JavaScriptQuickEdit"
+    },
+    {
+        "path": "extensions/default/QuickView",
+        "copy": [
+            "extensions/default/QuickView/QuickView.css",
+            "extensions/default/QuickView/*.svg"
+        ]
+    },
+    {
+        "path": "extensions/default/WebPlatformDocs",
+        "copy": [
+            "extensions/default/WebPlatformDocs/WebPlatformDocs.css",
+            "extensions/default/WebPlatformDocs/html.json",
+            "extensions/default/WebPlatformDocs/css.json",
+            "extensions/default/WebPlatformDocs/logo.svg"
+        ]
+    },
+    {
+        "path": "extensions/default/bramble",
+        "copy": [
+            "extensions/default/bramble/stylesheets/*.css"
+        ]
+    },
+    {
+        "path": "extensions/default/Autosave"
+    },
+    {
+        "path": "extensions/default/brackets-paste-and-indent"
+    },
+    {
+        "path": "extensions/default/BrambleUrlCodeHints",
+        "copy": [
+            "extensions/default/BrambleUrlCodeHints/style.css",
+            "extensions/default/BrambleUrlCodeHints/camera/camera-shutter-click-08.mp3",
+            "extensions/default/BrambleUrlCodeHints/glyphicons-12-camera.png",
+            "extensions/default/BrambleUrlCodeHints/selfiePreview.png"
+        ]
+    },
+    {
+        "path": "extensions/default/UploadFiles",
+        "copy": [
+            "extensions/default/UploadFiles/styles.css",
+            "extensions/default/UploadFiles/images/*.svg"
+        ]
+    },
+    {
+        "path": "extensions/default/bramble-move-file",
+        "copy": [
+            "extensions/default/bramble-move-file/styles/style.css",
+            "extensions/default/bramble-move-file/images/*.svg"
+        ]
+    },
+    {
+        "path": "extensions/default/brackets-show-whitespace"
+    }
 ]

--- a/src/extensions/bramble-extensions.json
+++ b/src/extensions/bramble-extensions.json
@@ -40,13 +40,6 @@
         ]
     },
     {
-        "path": "extensions/default/InlineTimingFunctionEditor",
-        "copy": [
-            "extensions/default/InlineTimingFunctionEditor/main.css",
-            "extensions/default/InlineTimingFunctionEditor/*.png"
-        ]
-    },
-    {
         "path": "extensions/default/JavaScriptQuickEdit"
     },
     {
@@ -68,7 +61,8 @@
     {
         "path": "extensions/default/bramble",
         "copy": [
-            "extensions/default/bramble/stylesheets/*.css"
+            "extensions/default/bramble/stylesheets/*.css",
+            "extensions/default/bramble/images/*"
         ]
     },
     {
@@ -101,6 +95,9 @@
         ]
     },
     {
-        "path": "extensions/default/brackets-show-whitespace"
+        "path": "extensions/default/brackets-show-whitespace",
+        "copy": [
+            "extensions/default/brackets-show-whitespace/styles/main.css"
+        ]
     }
 ]

--- a/src/extensions/bramble-extensions.json
+++ b/src/extensions/bramble-extensions.json
@@ -8,11 +8,11 @@
     "extensions/default/JavaScriptQuickEdit",
     "extensions/default/QuickView",
     "extensions/default/WebPlatformDocs",
-    "extensions/default/CodeFolding",
     "extensions/default/bramble",
     "extensions/default/Autosave",
     "extensions/default/brackets-paste-and-indent",
     "extensions/default/BrambleUrlCodeHints",
     "extensions/default/UploadFiles",
-    "extensions/default/bramble-move-file"
+    "extensions/default/bramble-move-file",
+    "extensions/default/brackets-show-whitespace"
 ]

--- a/src/utils/BrambleExtensionLoader.js
+++ b/src/utils/BrambleExtensionLoader.js
@@ -14,10 +14,14 @@ define(function (require, exports, module) {
     var basePath  = PathUtils.directory(window.location.href);
 
     // Load the list of extensions. If you want to add/remove extensions, do it in this json file.
-    var brambleExtensions = JSON.parse(require("text!extensions/bramble-extensions.json"));
+    var extensionInfo = JSON.parse(require("text!extensions/bramble-extensions.json"));
 
     // Disable any extensions we found on the query string's ?disableExtensions= param
     function _processDefaults(disableExtensions) {
+        var brambleExtensions = extensionInfo.map(function(info) {
+            return info.path;
+        });
+
         if(disableExtensions) {
             disableExtensions.split(",").forEach(function (ext) {
                 ext = ext.trim();

--- a/src/utils/BrambleExtensionLoader.js
+++ b/src/utils/BrambleExtensionLoader.js
@@ -10,123 +10,34 @@ define(function (require, exports, module) {
     "use strict";
 
     var PathUtils = require("thirdparty/path-utils/path-utils");
+    var Path      = require("filesystem/impls/filer/BracketsFiler").Path;
+    var basePath  = PathUtils.directory(window.location.href);
 
-    var basePath = PathUtils.directory(window.location.href);
+    // Load the list of extensions. If you want to add/remove extensions, do it in this json file.
+    var brambleExtensions = JSON.parse(require("text!extensions/bramble-extensions.json"));
 
-    /**
-     * We have a set of defaults we load if not instructed to do otherwise
-     * via the disableExtensions query param. These live in src/extensions/default/*
-     */
-    var brambleDefaultExtensions = [
-        "CSSCodeHints",
-        "HTMLCodeHints",
-        "JavaScriptCodeHints",
-        "InlineColorEditor",
-        "JavaScriptQuickEdit",
-        "QuickOpenCSS",
-        "QuickOpenHTML",
-        "QuickOpenJavaScript",
-        "QuickView",
-        "WebPlatformDocs",
-
-        // Custom extensions we want loaded by default
-        "bramble",
-        "Autosave",
-        "brackets-paste-and-indent",
-        "brackets-show-whitespace",
-        "BrambleUrlCodeHints",
-        "UploadFiles",
-        "bramble-move-file"
-    ];
-
-    /**
-     * There are some Brackets default extensions that we don't load
-     * but which a user might want to enable (note: not all the defaults
-     * they ship will work in a browser, so they aren't all here). We
-     * support loading these below via the enableExtensions param.
-     */
-    var bracketsDefaultExtensions = [
-        "SVGCodeHints",
-        "HtmlEntityCodeHints",
-        "LESSSupport",
-        "CloseOthers",
-        "InlineTimingFunctionEditor",
-        "JSLint",
-        "QuickOpenCSS",
-        "RecentProjects",
-        "UrlCodeHints",
-        "CodeFolding"
-    ];
-
-    /**
-     * Other extensions we've tested and deemed useful in the Bramble context.
-     * These live in src/extensions/extra/* and are usually submodules.  If you
-     * add a new extension there, update this array also.  You can have this load
-     * by adding the extension name to the enableExtensions query param.
-     */
-    var extraExtensions = [
-        "brackets-cdn-suggestions",    // https://github.com/szdc/brackets-cdn-suggestions
-        "HTMLHinter",
-        "MDNDocs",
-        "SVGasXML",
-        "bramble-watch-index.html"
-    ];
-
-    // Disable any extensions we found on the query string's disableExtensions param
+    // Disable any extensions we found on the query string's ?disableExtensions= param
     function _processDefaults(disableExtensions) {
         if(disableExtensions) {
             disableExtensions.split(",").forEach(function (ext) {
                 ext = ext.trim();
-                var idx = brambleDefaultExtensions.indexOf(ext);
+                var idx = brambleExtensions.indexOf(ext);
                 if (idx > -1) {
                     console.log('[Brackets] Disabling default extension `' + ext + '`');
-                    brambleDefaultExtensions.splice(idx, 1);
+                    brambleExtensions.splice(idx, 1);
                 }
             });
         }
 
-        return brambleDefaultExtensions.map(function (ext) {
+        return brambleExtensions.map(function (ext) {
             return {
                 name: ext,
-                path: basePath + "extensions/default/" + ext
+                path: Path.join(basePath, ext)
             };
         });
     }
 
-    // Add any extra extensions we found on the query string's enableExtensions param
-    function _processExtras(enableExtensions) {
-        var extras = [];
-
-        if(enableExtensions) {
-            enableExtensions.split(",").forEach(function (ext) {
-                ext = ext.trim();
-
-                // Extension is in src/extensions/extra/*
-                if (extraExtensions.indexOf(ext) > -1) {
-                    console.log('[Brackets] Loading additional extension `' + ext + '`');
-                    extras.push({
-                        name: ext,
-                        path: basePath + "extensions/extra/" + ext
-                    });
-                }
-
-                // Extension is in src/extensions/default/* (we don't enable all Brackets exts)
-                if (bracketsDefaultExtensions.indexOf(ext) > -1) {
-                    console.log('[Brackets] Loading additional extension `' + ext + '`');
-                    extras.push({
-                        name: ext,
-                        path: basePath + "extensions/default/" + ext
-                    });
-                }
-            });
-        }
-
-        return extras;
-    }
-
     exports.getExtensionList = function(params) {
-        return []
-            .concat(_processDefaults(params.get("disableExtensions")))
-            .concat(_processExtras(params.get("enableExtensions")));
+        return _processDefaults(params.get("disableExtensions"));
     };
 });


### PR DESCRIPTION
I've reworked our extension loading to properly package extensions in `dist/` as minified requirejs bundles, and changed how we copy files over from `src/` to `dist/` so we only have what we need.  I'll need this for my next trick with service worker cache tuning in #634.