### PR TITLE
Fix #639: Stop using build-config task and triggering git perm issues on Windows

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -126,7 +126,10 @@ module.exports = function (grunt) {
                             'thirdparty/slowparse/locale/*',
                             'thirdparty/github-markdown.css',
                             'LiveDevelopment/launch.html',
-                            'hosted.*'
+                            'hosted.*',
+                            // XXXBramble: we don't use src/config.json like Brackets does,
+                            // but it needs to exist in dist/ so copy it
+                            'config.json'
                         ]
                     },
                     /* extensions and CodeMirror modes */
@@ -498,8 +501,9 @@ module.exports = function (grunt) {
          'npm-install', */
         'cleanempty',
         'exec:clean-nls',
-        'usemin',
-        'build-config'
+        'usemin'
+        /* XXXBramble: we skip this, since we don't bother with its info, and copy it in copy:dist
+        'build-config' */
     ]);
 
     // task: build dist/ for browser


### PR DESCRIPTION
This should fix things for @Pomax and others on Windows, who were being asked for passwords with GitHub when doing `npm run build`.  We were using Brackets build code to talk to git and get info that we would then merge into the `src/config.json` file.  We don't use any of it in Bramble, so this just eliminates that, and copies the file as it exists now over to `dist/`, which is necessary because some of the `config` values in it are used throughout our code.

To test this, run `npm run build` on windows and make sure it doesn't bail with perm issues.