### PR TITLE
Fix #592: Update our travis-ci config to use a C++ compiler that can compile iltorb

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,13 +9,18 @@ branches:
   only:
   - master
   - production
-notifications:
-  irc: "irc.mozilla.org#thimble"
 env:
   global:
+    - CXX=g++-4.8
     - secure: OvDWteGJ/ctOzXudDb8icaLCtdJTd1HbQq5T9HvS7ZF8IDs6xM+atqxYWeyC+2sm7fLNkWjndcKrXFqZ3TRltW7ibaKreUMtUVaVKc7mGBNBn/gVfCNvHRlbDYr6bMUVapk9x1Ql6p2jE/Ss+p2EEGkzvHPKn2RMRWOQQQM7wTQ=
   matrix:
     - AWS_ACCESS_KEY_ID=AKIAI7XHSZFYVHFRTRIA CLOUDFRONT_DISTRIBUTION_ID=ENS8DUD0WOHD9
+addons:
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+    packages:
+      - g++-4.8
 deploy:
   - provider: s3
     access_key_id: AKIAI7XHSZFYVHFRTRIA

--- a/README.md
+++ b/README.md
@@ -34,6 +34,11 @@ Navigate to the root of the directory you cloned and run:
 $ npm install
 ```
 
+NOTE: if you are running on Windows, and experience a build error with the `iltorb` package,
+consider adding the `--no-optional` flag to have npm skip installing `iltorb`, which is optional
+and requires python, gyp and a working c++ build environment.
+See comment in https://github.com/mozilla/brackets/pull/588#issuecomment-280438175
+
 Step 3: run the build
 
 You can build Bramble by running the npm build task:


### PR DESCRIPTION
This is coming up a bunch in other PRs that can't pass travis.

I also removed the old irc notification stuff, since we aren't using it.