### PR TITLE
Addressed issue #1100 from Thimble. Made the sidebar switch color along when the theme changes

### DIFF
--- a/src/extensions/default/bramble/stylesheets/sidebarTheme.css
+++ b/src/extensions/default/bramble/stylesheets/sidebarTheme.css
@@ -16,10 +16,16 @@ div.working-set-option-btn[style] {
 /* Dark Theme Color */
 /* TODO - move this to the dark theme CSS later */
 
-#sidebar {
+body[data-theme='dark-theme'] #sidebar {
     background-color: black;
     text-shadow: none;
 }
+
+body[data-theme='light-theme'] #sidebar {
+    background-color: white;
+    text-shadow: none;
+}
+
 
 #project-files-container {
     padding-left: 0;
@@ -37,7 +43,7 @@ div.working-set-option-btn[style] {
 li.jstree-leaf a span,
 li.jstree-leaf span.extension {
     font-size: 15px;
-    color: rgba(255,255,255,.5);
+    color: #2893ef;
 }
 
 li.jstree-closed > a span,
@@ -88,7 +94,7 @@ li.jstree-leaf a.selected-node .extension {
 li.jstree-leaf a:not(.selected-node):hover,
 li.jstree-open a:first-of-type:hover,
 li.jstree-closed a:first-of-type:hover {
-    background: rgba(255,255,255,.08);
+    background: rgba(45,153,97,1);
 }
 
 

--- a/src/extensions/default/bramble/stylesheets/sidebarTheme.css
+++ b/src/extensions/default/bramble/stylesheets/sidebarTheme.css
@@ -161,7 +161,7 @@ li.jstree-open > ul:empty:after {
 li.jstree-closed a.context-node,
 li.jstree-open a.context-node,
 li.jstree-leaf a.context-node {
-    background: rgba(255,255,255,.08);
+    background: rgba(0,0,0,.08);
 }
 
 

--- a/src/extensions/default/bramble/stylesheets/sidebarTheme.css
+++ b/src/extensions/default/bramble/stylesheets/sidebarTheme.css
@@ -161,7 +161,7 @@ li.jstree-open > ul:empty:after {
 li.jstree-closed a.context-node,
 li.jstree-open a.context-node,
 li.jstree-leaf a.context-node {
-    background: rgba(255,255,255,0.08);
+    background: rgba(255,255,255,.08);
 }
 
 

--- a/src/view/ThemeManager.js
+++ b/src/view/ThemeManager.js
@@ -237,9 +237,8 @@ define(function (require, exports, module) {
                     return result.content;
                 })
                 .then(function (cssContent) {
-                    $("body").toggleClass("dark", theme.dark);
                     styleNode.text(cssContent);
-
+                    $("body").attr('data-theme',theme.name);
                     pending.resolve(theme);
                 });
             });


### PR DESCRIPTION
In the sidebarTheme.css there are now to classes for the sidebar object, the 'dark' class, and the 'light' class. 

In the ThemeManager.js file, I modified the loadCurrentTheme function such that it toggles the appropriate class on the sidebar element and makes sure that there is always a 'dark' or 'light' class active, the default being the 'light' class.