### PR TITLE
Support Drag and Drop of Folders as well as files, fixes #668

### DIFF
--- a/src/filesystem/impls/filer/ArchiveUtils.js
+++ b/src/filesystem/impls/filer/ArchiveUtils.js
@@ -71,7 +71,7 @@ define(function (require, exports, module) {
             return;
         }
 
-        var root = StartupState.project("root");
+        var root = options.root || StartupState.project("root");
         var destination = Path.resolve(options.destination || root);
 
         function _unzip(data){
@@ -206,9 +206,16 @@ define(function (require, exports, module) {
         });
     }
 
-    function untar(tarArchive, callback) {
+    function untar(tarArchive, options, callback) {
+        if(typeof options === 'function') {
+            callback = options;
+            options = {};
+        }
+        options = options || {};
+        callback = callback || function(){};
+
         var untarWorker = new Worker("thirdparty/bitjs/bitjs-untar.min.js");
-        var root = StartupState.project("root");
+        var root = options.root || StartupState.project("root");
         var pending = null;
 
         function extract(path, data, callback) {

--- a/src/filesystem/impls/filer/ArchiveUtils.js
+++ b/src/filesystem/impls/filer/ArchiveUtils.js
@@ -18,7 +18,7 @@ define(function (require, exports, module) {
     var fs              = Filer.fs();
 
     // Mac and Windows clutter zip files with extra files/folders we don't need
-    function _skipFile(filename) {
+    function skipFile(filename) {
         var basename = Path.basename(filename);
 
         // Skip OS X additions we don't care about in the browser fs
@@ -80,7 +80,7 @@ define(function (require, exports, module) {
             var filenames = [];
 
             archive.filter(function(relPath, file) {
-                if(_skipFile(file.name)) {
+                if(skipFile(file.name)) {
                     return;
                 }
 
@@ -215,7 +215,7 @@ define(function (require, exports, module) {
             path = Path.resolve(root, path);
             var basedir = Path.dirname(path);
 
-            if(_skipFile(path)) {
+            if(skipFile(path)) {
                 return callback();
             }
 
@@ -262,6 +262,7 @@ define(function (require, exports, module) {
         untarWorker.postMessage({file: tarArchive.buffer});
     }
 
+    exports.skipFile = skipFile;
     exports.archive = archive;
     exports.unzip = unzip;
     exports.untar = untar;

--- a/src/filesystem/impls/filer/lib/FileImport.js
+++ b/src/filesystem/impls/filer/lib/FileImport.js
@@ -41,12 +41,18 @@ define(function (require, exports, module) {
     // 5MB size limit for imported archives (zip & tar)
     var archiveByteLimit = 5242880;
 
-    exports.import = function(dataTransfer, callback) {
-        var options = {
+    // Support passing a DataTransfer object, or a FileList
+    exports.import = function(source, callback) {
+        if(!(source instanceof FileList || source instanceof DataTransfer)) {
+            callback(new Error("[Bramble] expected DataTransfer or FileList to FileImport.import()"));
+            return;
+        }
+
+       var options = {
             byteLimit: byteLimit,
             archiveByteLimit: archiveByteLimit
         };
         var strategy = _create(options);
-        return strategy.import(dataTransfer, callback);
+        return strategy.import(source, callback);
     };
 });

--- a/src/filesystem/impls/filer/lib/FileImport.js
+++ b/src/filesystem/impls/filer/lib/FileImport.js
@@ -1,0 +1,52 @@
+
+/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
+/*global define*/
+
+define(function (require, exports, module) {
+    "use strict";
+
+    var LegacyFileImport = require("filesystem/impls/filer/lib/LegacyFileImport"),
+        WebKitFileImport = require("filesystem/impls/filer/lib/WebKitFileImport");
+
+    /**
+     * XXXBramble: the Drag and Drop and File APIs are a mess of incompatible
+     * standards and implementations.  This tries to deal with the fact that some
+     * browsers allow you to drag-and-drop folders, and some don't.  All
+     * browsers we support will do file drag-and-drop, so we want to make sure
+     * we always allow that.
+     *
+     * Currently, dragging folders works in Chrome (13), Edge, Firefox (50)
+     * but not in IE, Opera, or Safari.
+     *
+     * See:
+     *  - https://html.spec.whatwg.org/#the-datatransferitem-interface
+     *  - https://developer.mozilla.org/en-US/docs/Web/API/DataTransfer
+     *  - https://developer.mozilla.org/en-US/docs/Web/API/DataTransferItemList
+     *  - https://developer.mozilla.org/en-US/docs/Web/API/DataTransferItem
+     *  - https://developer.mozilla.org/en-US/docs/Web/API/DataTransferItem/webkitGetAsEntry
+     */
+    var _create = (function() {
+        if(window.DataTransferItem                            &&
+           window.DataTransferItem.prototype.webkitGetAsEntry &&
+           window.DataTransferItemList) {
+               return WebKitFileImport.create;
+        }
+        return LegacyFileImport.create;
+    }());
+
+    // 3MB size limit for imported files. If you change this, also change the
+    // error message we generate in rejectImport() below!
+    var byteLimit = 3145728;
+
+    // 5MB size limit for imported archives (zip & tar)
+    var archiveByteLimit = 5242880;
+
+    exports.import = function(dataTransfer, callback) {
+        var options = {
+            byteLimit: byteLimit,
+            archiveByteLimit: archiveByteLimit
+        };
+        var strategy = _create(options);
+        return strategy.import(dataTransfer, callback);
+    };
+});

--- a/src/filesystem/impls/filer/lib/FileImport.js
+++ b/src/filesystem/impls/filer/lib/FileImport.js
@@ -6,7 +6,8 @@ define(function (require, exports, module) {
     "use strict";
 
     var LegacyFileImport = require("filesystem/impls/filer/lib/LegacyFileImport"),
-        WebKitFileImport = require("filesystem/impls/filer/lib/WebKitFileImport");
+        WebKitFileImport = require("filesystem/impls/filer/lib/WebKitFileImport"),
+        FileSystemCache = require("filesystem/impls/filer/FileSystemCache");
 
     /**
      * XXXBramble: the Drag and Drop and File APIs are a mess of incompatible
@@ -48,11 +49,13 @@ define(function (require, exports, module) {
             return;
         }
 
-       var options = {
+        var options = {
             byteLimit: byteLimit,
             archiveByteLimit: archiveByteLimit
         };
         var strategy = _create(options);
-        return strategy.import(source, callback);
+        return strategy.import(source, function(err) {
+            FileSystemCache.refresh(callback);
+        });
     };
 });

--- a/src/filesystem/impls/filer/lib/LegacyFileImport.js
+++ b/src/filesystem/impls/filer/lib/LegacyFileImport.js
@@ -49,8 +49,9 @@ define(function (require, exports, module) {
         this.archiveByteLimit = options.archiveByteLimit;
     }
 
-    LegacyFileImport.prototype.import = function(dataTransfer, callback) {
-        var files = dataTransfer.files;
+    // We want event.dataTransfer.files for legacy browsers.
+    LegacyFileImport.prototype.import = function(source, callback) {
+        var files = source instanceof DataTransfer ? source.files : source;
         var byteLimit = this.byteLimit;
         var archiveByteLimit = this.archiveByteLimit;
         var pathList = [];

--- a/src/filesystem/impls/filer/lib/LegacyFileImport.js
+++ b/src/filesystem/impls/filer/lib/LegacyFileImport.js
@@ -244,7 +244,7 @@ define(function (require, exports, module) {
             });
     };
 
-    exports.create = function(byteLimit) {
-        return new LegacyFileImport(byteLimit);
+    exports.create = function(options) {
+        return new LegacyFileImport(options);
     };
 });

--- a/src/filesystem/impls/filer/lib/LegacyFileImport.js
+++ b/src/filesystem/impls/filer/lib/LegacyFileImport.js
@@ -91,7 +91,7 @@ define(function (require, exports, module) {
         function handleZipFile(deferred, file, filename, buffer, encoding) {
             var basename = Path.basename(filename);
 
-            ArchiveUtils.unzip(buffer, function(err) {
+            ArchiveUtils.unzip(buffer, { root: parentPath }, function(err) {
                 if (err) {
                     errorList.push({path: filename, error: Strings.DND_ERROR_UNZIP});
                     deferred.reject(err);
@@ -109,7 +109,7 @@ define(function (require, exports, module) {
         function handleTarFile(deferred, file, filename, buffer, encoding) {
             var basename = Path.basename(filename);
 
-            ArchiveUtils.untar(buffer, function(err) {
+            ArchiveUtils.untar(buffer, { root: parentPath }, function(err) {
                 if (err) {
                     errorList.push({path: filename, error: Strings.DND_ERROR_UNTAR});
                     deferred.reject(err);

--- a/src/filesystem/impls/filer/lib/LegacyFileImport.js
+++ b/src/filesystem/impls/filer/lib/LegacyFileImport.js
@@ -1,0 +1,248 @@
+ /*
+ * Copyright (c) 2013 Adobe Systems Incorporated. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ *
+ */
+
+
+/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
+/*global define, $, FileReader*/
+
+define(function (require, exports, module) {
+    "use strict";
+
+    var _               = require("thirdparty/lodash"),
+        Async           = require("utils/Async"),
+        Dialogs         = require("widgets/Dialogs"),
+        DefaultDialogs  = require("widgets/DefaultDialogs"),
+        FileSystem      = require("filesystem/FileSystem"),
+        FileUtils       = require("file/FileUtils"),
+        Strings         = require("strings"),
+        StringUtils     = require("utils/StringUtils"),
+        Filer           = require("filesystem/impls/filer/BracketsFiler"),
+        Path            = Filer.Path,
+        Content         = require("filesystem/impls/filer/lib/content"),
+        LanguageManager = require("language/LanguageManager"),
+        StartupState    = require("bramble/StartupState"),
+        ArchiveUtils    = require("filesystem/impls/filer/ArchiveUtils"),
+        FilerUtils      = require("filesystem/impls/filer/FilerUtils");
+
+    function LegacyFileImport(options) {
+        this.byteLimit = options.byteLimit;
+        this.archiveByteLimit = options.archiveByteLimit;
+    }
+
+    LegacyFileImport.prototype.import = function(dataTransfer, callback) {
+        var files = dataTransfer.files;
+        var byteLimit = this.byteLimit;
+        var archiveByteLimit = this.archiveByteLimit;
+        var pathList = [];
+        var errorList = [];
+
+        if (!(files && files.length)) {
+            return callback();
+        }
+
+        function shouldOpenFile(filename, encoding) {
+            return Content.isImage(Path.extname(filename)) || encoding === "utf8";
+        }
+
+        function handleRegularFile(deferred, file, filename, buffer, encoding) {
+            // Don't write thing like .DS_Store, thumbs.db, etc.
+            if(ArchiveUtils.skipFile(filename)) {
+                deferred.resolve();
+                return;
+            }
+
+            file.write(buffer, {encoding: encoding}, function(err) {
+                if (err) {
+                    errorList.push({path: filename, error: "unable to write file: " + err.message || ""});
+                    deferred.reject(err);
+                    return;
+                }
+
+                // See if this file is worth trying to open in the editor or not
+                if(shouldOpenFile(filename, encoding)) {
+                    pathList.push(filename);
+                }
+
+                deferred.resolve();
+            });
+        }
+
+        function handleZipFile(deferred, file, filename, buffer, encoding) {
+            var basename = Path.basename(filename);
+
+            ArchiveUtils.unzip(buffer, function(err) {
+                if (err) {
+                    errorList.push({path: filename, error: Strings.DND_ERROR_UNZIP});
+                    deferred.reject(err);
+                    return;
+                }
+
+                Dialogs.showModalDialog(
+                    DefaultDialogs.DIALOG_ID_INFO,
+                    Strings.DND_SUCCESS_UNZIP_TITLE,
+                    StringUtils.format(Strings.DND_SUCCESS_UNZIP, basename)
+                ).getPromise().then(deferred.resolve, deferred.reject);
+            });
+        }
+
+        function handleTarFile(deferred, file, filename, buffer, encoding) {
+            var basename = Path.basename(filename);
+
+            ArchiveUtils.untar(buffer, function(err) {
+                if (err) {
+                    errorList.push({path: filename, error: Strings.DND_ERROR_UNTAR});
+                    deferred.reject(err);
+                    return;
+                }
+
+                Dialogs.showModalDialog(
+                    DefaultDialogs.DIALOG_ID_INFO,
+                    Strings.DND_SUCCESS_UNTAR_TITLE,
+                    StringUtils.format(Strings.DND_SUCCESS_UNTAR, basename)
+                ).getPromise().then(deferred.resolve, deferred.reject);
+            });
+        }
+
+        /**
+         * Determine whether we want to import this file at all.  If it's too large
+         * or not a mime type we care about, reject it.
+         */
+        function rejectImport(item) {
+            var ext = Path.extname(item.name);
+            var sizeLimit = Content.isArchive(ext) ? archiveByteLimit : byteLimit;
+            var sizeLimitMb = (sizeLimit / (1024 * 1024)).toString();
+
+            if (item.size > sizeLimit) {
+                return new Error(StringUtils.format(Strings.DND_MAX_SIZE_EXCEEDED, sizeLimitMb));
+            }
+
+            // If we don't know about this language type, or the OS doesn't think
+            // it's text, reject it.
+            var isSupported = !!LanguageManager.getLanguageForExtension(FilerUtils.normalizeExtension(ext));
+            var typeIsText = Content.isTextType(item.type);
+
+            if (isSupported || typeIsText) {
+                return null;
+            }
+            return new Error(Strings.DND_UNSUPPORTED_FILE_TYPE);
+        }
+
+        function prepareDropPaths(fileList) {
+            // Convert FileList object to an Array with all image files first, then CSS
+            // followed by HTML files at the end, since we need to write any .css, .js, etc.
+            // resources first such that Blob URLs can be generated for these resources
+            // prior to rewriting an HTML file.
+            function rateFileByType(filename) {
+                var ext = Path.extname(filename);
+
+                // We want to end up with: [images, ..., js, ..., css, html]
+                // since CSS can include images, and HTML can include CSS or JS.
+                // We also treat .md like an HTML file, since we render them.
+                if(Content.isHTML(ext) || Content.isMarkdown(ext)) {
+                    return 10;
+                } else if(Content.isCSS(ext)) {
+                    return 8;
+                } else if(Content.isImage(ext)) {
+                    return 1;
+                }
+                return 3;
+            }
+
+            return _.toArray(fileList).sort(function(a,b) {
+                a = rateFileByType(a.name);
+                b = rateFileByType(b.name);
+
+                if(a < b) {
+                    return -1;
+                }
+                if(a > b) {
+                    return 1;
+                }
+                return 0;
+            });
+        }
+
+        function maybeImportFile(item) {
+            var deferred = new $.Deferred();
+            var reader = new FileReader();
+
+            // Check whether we want to import this file at all before we start.
+            var wasRejected = rejectImport(item);
+            if (wasRejected) {
+                errorList.push({path: item.name, error: wasRejected.message});
+                deferred.reject(wasRejected);
+                return deferred.promise();
+            }
+
+            reader.onload = function(e) {
+                delete reader.onload;
+
+                var filename = Path.join(StartupState.project("root"), item.name);
+                var file = FileSystem.getFileForPath(filename);
+                var ext = Path.extname(filename).toLowerCase();
+
+                // Create a Filer Buffer, and determine the proper encoding. We
+                // use the extension, and also the OS provided mime type for clues.
+                var buffer = new Filer.Buffer(e.target.result);
+                var utf8FromExt = Content.isUTF8Encoded(ext);
+                var utf8FromOS = Content.isTextType(item.type);
+                var encoding =  utf8FromExt || utf8FromOS ? 'utf8' : null;
+                if(encoding === 'utf8') {
+                    buffer = buffer.toString();
+                }
+
+                // Special-case .zip files, so we can offer to extract the contents
+                if(ext === ".zip") {
+                    handleZipFile(deferred, file, filename, buffer, encoding);
+                } else if(ext === ".tar") {
+                    handleTarFile(deferred, file, filename, buffer, encoding);
+                } else {
+                    handleRegularFile(deferred, file, filename, buffer, encoding);
+                }
+            };
+
+            // Deal with error cases, for example, trying to drop a folder vs. file
+            reader.onerror = function(e) {
+                delete reader.onerror;
+
+                errorList.push({path: item.name, error: e.target.error.message});
+                deferred.reject(e.target.error);
+            };
+            reader.readAsArrayBuffer(item);
+
+            return deferred.promise();
+        }
+
+        Async.doSequentially(prepareDropPaths(files), maybeImportFile, false)
+            .done(function() {
+                callback(null, pathList);
+            })
+            .fail(function() {
+                callback(errorList);
+            });
+    };
+
+    exports.create = function(byteLimit) {
+        return new LegacyFileImport(byteLimit);
+    };
+});

--- a/src/filesystem/impls/filer/lib/WebKitFileImport.js
+++ b/src/filesystem/impls/filer/lib/WebKitFileImport.js
@@ -49,8 +49,9 @@ define(function (require, exports, module) {
         this.archiveByteLimit = options.archiveByteLimit;
     }
 
-    WebKitFileImport.prototype.import = function(dataTransfer, callback) {
-        var items = dataTransfer.items;
+    // We want event.dataTransfer.items for WebKit style browsers
+    WebKitFileImport.prototype.import = function(source, callback) {
+        var items = source instanceof DataTransfer ? source.items : source;
         var byteLimit = this.byteLimit;
         var archiveByteLimit = this.archiveByteLimit;
         var pathList = [];

--- a/src/filesystem/impls/filer/lib/WebKitFileImport.js
+++ b/src/filesystem/impls/filer/lib/WebKitFileImport.js
@@ -1,0 +1,295 @@
+ /*
+ * Copyright (c) 2013 Adobe Systems Incorporated. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ *
+ */
+
+
+/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
+/*global define, $, FileReader*/
+
+define(function (require, exports, module) {
+    "use strict";
+
+    var _               = require("thirdparty/lodash"),
+        Async           = require("utils/Async"),
+        Dialogs         = require("widgets/Dialogs"),
+        DefaultDialogs  = require("widgets/DefaultDialogs"),
+        FileSystem      = require("filesystem/FileSystem"),
+        FileUtils       = require("file/FileUtils"),
+        Strings         = require("strings"),
+        StringUtils     = require("utils/StringUtils"),
+        Filer           = require("filesystem/impls/filer/BracketsFiler"),
+        Path            = Filer.Path,
+        Content         = require("filesystem/impls/filer/lib/content"),
+        LanguageManager = require("language/LanguageManager"),
+        StartupState    = require("bramble/StartupState"),
+        ArchiveUtils    = require("filesystem/impls/filer/ArchiveUtils"),
+        FilerUtils      = require("filesystem/impls/filer/FilerUtils");
+
+    function WebKitFileImport(byteLimit) {
+        this.byteLimit = options.byteLimit;
+        this.archiveByteLimit = options.archiveByteLimit;
+    }
+
+    WebKitFileImport.prototype.import = function(dataTransfer, callback) {
+        var items = dataTransfer.items;
+        var byteLimit = this.byteLimit;
+        var archiveByteLimit = this.archiveByteLimit;
+        var pathList = [];
+        var errorList = [];
+        var started = 0;
+        var completed = 0;
+
+        if (!(items && items.length)) {
+            return callback();
+        }
+
+        function shouldOpenFile(filename, encoding) {
+            return Content.isImage(Path.extname(filename)) || encoding === "utf8";
+        }
+
+        function checkDone() {
+            console.log("checkDone", started, completed);
+            if(started === completed) {
+                if(errorList.length) {
+                    console.log("done with errors", errorList);
+                    callback(errorList);
+                } else {
+                    console.log("done without errors", pathList);
+                    callback(null, pathList);
+                }
+            }
+        }
+
+        function onError(deferred, path, err) {
+            completed++;
+            errorList.push({path: path, error: err.message});
+            deferred.reject(err);
+            checkDone();
+        }
+
+        function onSuccess(deferred) {
+            completed++;
+            deferred.resolve();
+            checkDone();
+        }
+
+        function handleDirectory(deferred, entry, path) {
+            function readDir(folder, callback) {
+                var reading = 0
+
+                function read(reader) {
+                    reading++;
+                    reader.readEntries(function(entries) {
+                        reading--;
+                        for(var entry of entries) {
+                            if(entry.isDirectory) {
+                                maybeImportDirectory(path, entry);
+                            } else {
+                                maybeImportFile(path, entry);
+                            }
+                        }
+                        if(entries.length) {
+                            read(reader);
+                        } else if(reading === 0) {
+                            callback();
+                        }
+                    });
+                }
+                read(folder.createReader())
+            }
+
+            FileSystem.getDirectoryForPath(path).create(function(err) {
+                if(err && err.code !== "EEXIST") {
+                    onError(deferred, path, err);
+                    return;
+                }
+
+                // Manually increase completed count by 1 for dir itself
+                completed++;
+
+                readDir(entry, function(files) {
+                    deferred.resolve();
+                });
+            });
+        }
+
+        function handleRegularFile(deferred, file, filename, buffer, encoding) {
+            file.write(buffer, {encoding: encoding}, function(err) {
+                if (err) {
+                    onError(deferred, filename, err);
+                    return;
+                }
+
+                // See if this file is worth trying to open in the editor or not
+                if(shouldOpenFile(filename, encoding)) {
+                    pathList.push(filename);
+                }
+
+                onSuccess(deferred);
+            });
+        }
+
+        function handleZipFile(deferred, file, filename, buffer, encoding) {
+            var basename = Path.basename(filename);
+
+            ArchiveUtils.unzip(buffer, function(err) {
+                if (err) {
+                    onError(deferred, filename, new Error(Strings.DND_ERROR_UNZIP));
+                    return;
+                }
+
+                onSuccess(deferred);
+            });
+        }
+
+        function handleTarFile(deferred, file, filename, buffer, encoding) {
+            var basename = Path.basename(filename);
+
+            ArchiveUtils.untar(buffer, function(err) {
+                if (err) {
+                    onError(deferred, filename, new Error(Strings.DND_ERROR_UNTAR));
+                    return;
+                }
+
+                onSuccess(deferred);
+            });
+        }
+
+        /**
+         * Determine whether we want to import this file at all.  If it's too large
+         * or not a mime type we care about, reject it.
+         */
+        function rejectImport(filename, size) {
+            var ext = Path.extname(item.name);
+            var mime = Content.mimeFromExt(ext);
+            var sizeLimit = Content.isArchive(ext) ? archiveByteLimit : byteLimit;
+            var sizeLimitMb = (sizeLimit / (1024 * 1024)).toString();
+
+            if (item.size > sizeLimit) {
+                return new Error(StringUtils.format(Strings.DND_MAX_SIZE_EXCEEDED, sizeLimitMb));
+            }
+
+            // If we don't know about this language type, or the OS doesn't think
+            // it's text, reject it.
+            var isSupported = !!LanguageManager.getLanguageForExtension(FilerUtils.normalizeExtension(ext));
+            var typeIsText = Content.isTextType(mime);
+
+            if (isSupported || typeIsText) {
+                return null;
+            }
+            return new Error(Strings.DND_UNSUPPORTED_FILE_TYPE);
+        }
+
+        function maybeImportDirectory(parentPath, entry, deferred) {
+            started++;
+            var fullPath = Path.join(parentPath, entry.name);
+            deferred = deferred || new $.Deferred();
+            handleDirectory(deferred, entry, fullPath);
+            return deferred.promise();
+        }
+
+        function maybeImportFile(parentPath, entry, deferred) {
+            started++;
+            deferred = deferred || new $.Deferred();
+
+            entry.file(function(file) {
+                var reader = new FileReader();
+
+                reader.onload = function(e) {
+                    delete reader.onload;
+
+                    var filename = Path.join(parentPath, entry.name);
+                    var file = FileSystem.getFileForPath(filename);
+                    var ext = Path.extname(filename).toLowerCase();
+
+                    // Create a Filer Buffer, and determine the proper encoding.
+                    var buffer = new Filer.Buffer(e.target.result);
+                    var utf8FromExt = Content.isUTF8Encoded(ext);
+                    var encoding = utf8FromExt ? "utf8" : null;
+                    if(utf8FromExt) {
+                        buffer = buffer.toString();
+                    }
+
+                    // Don't bother writing things like .DS_Store, thumbs.db, etc.
+                    if(ArchiveUtils.skipFile(filename)) {
+                        onSuccess(deferred);
+                        return;
+                    }
+
+                    // Check whether we want to import this file at all before we start.
+                    var wasRejected = rejectImport(entry.name, buffer.byteLength);
+                    if (wasRejected) {
+                        onError(deferred, entry.name, wasRejected);
+                        return;
+                    }
+
+                    // Special-case .zip files, so we can offer to extract the contents
+                    if(ext === ".zip") {
+                        handleZipFile(deferred, file, filename, buffer, encoding);
+                    } else if(ext === ".tar") {
+                        handleTarFile(deferred, file, filename, buffer, encoding);
+                    } else {
+                        handleRegularFile(deferred, file, filename, buffer, encoding);
+                    }
+                };
+
+                // Deal with error cases, for example, trying to drop a folder vs. file
+                reader.onerror = function(e) {
+                    delete reader.onerror;
+
+                    onError(deferred, entry.name, e.target.error);
+                };
+
+                reader.readAsArrayBuffer(file);
+            }, function(err) {
+                onError(deferred, entry.name, err);
+            });
+
+            return deferred.promise();
+        }
+
+        function maybeImport(entry, count) {
+            var deferred = new $.Deferred();
+            var err;
+
+            if(entry.isDirectory) {
+                maybeImportDirectory(StartupState.project("root"), entry, deferred);
+            } else if (entry.isFile) {
+                maybeImportFile(StartupState.project("root"), entry, deferred);
+            } else {
+                // Skip it, we don't know what this is
+                err = new Error(Strings.DND_UNSUPPORTED_FILE_TYPE);
+                deferred.reject(err);
+            }
+        }
+
+        // For security reasons, the DataTransferItemList is prone to going out of
+        // scope, so we have to do this in a synchronous loop, otherwise I'd use async/promises.
+        for(var i=0, l=items.length; i<l; i++) {
+            maybeImport(items[i].webkitGetAsEntry());
+        }
+    };
+
+    exports.create = function(byteLimit) {
+        return new WebKitFileImport(byteLimit);
+    };
+});

--- a/src/filesystem/impls/filer/lib/WebKitFileImport.js
+++ b/src/filesystem/impls/filer/lib/WebKitFileImport.js
@@ -153,7 +153,7 @@ define(function (require, exports, module) {
         function handleZipFile(deferred, file, filename, buffer, encoding) {
             var basename = Path.basename(filename);
 
-            ArchiveUtils.unzip(buffer, function(err) {
+            ArchiveUtils.unzip(buffer, { root: parentPath }, function(err) {
                 if (err) {
                     onError(deferred, filename, new Error(Strings.DND_ERROR_UNZIP));
                     return;
@@ -166,7 +166,7 @@ define(function (require, exports, module) {
         function handleTarFile(deferred, file, filename, buffer, encoding) {
             var basename = Path.basename(filename);
 
-            ArchiveUtils.untar(buffer, function(err) {
+            ArchiveUtils.untar(buffer, { root: parentPath }, function(err) {
                 if (err) {
                     onError(deferred, filename, new Error(Strings.DND_ERROR_UNTAR));
                     return;

--- a/src/filesystem/impls/filer/lib/WebKitFileImport.js
+++ b/src/filesystem/impls/filer/lib/WebKitFileImport.js
@@ -68,13 +68,10 @@ define(function (require, exports, module) {
         }
 
         function checkDone() {
-            console.log("checkDone", started, completed);
             if(started === completed) {
                 if(errorList.length) {
-                    console.log("done with errors", errorList);
                     callback(errorList);
                 } else {
-                    console.log("done without errors", pathList);
                     callback(null, pathList);
                 }
             }

--- a/src/filesystem/impls/filer/lib/WebKitFileImport.js
+++ b/src/filesystem/impls/filer/lib/WebKitFileImport.js
@@ -92,19 +92,22 @@ define(function (require, exports, module) {
 
         function handleDirectory(deferred, entry, path) {
             function readDir(folder, callback) {
-                var reading = 0
+                var reading = 0;
 
                 function read(reader) {
                     reading++;
+
                     reader.readEntries(function(entries) {
                         reading--;
-                        for(var entry of entries) {
+
+                        entries.forEach(function(entry) {
                             if(entry.isDirectory) {
                                 maybeImportDirectory(path, entry);
                             } else {
                                 maybeImportFile(path, entry);
                             }
-                        }
+                        });
+
                         if(entries.length) {
                             read(reader);
                         } else if(reading === 0) {
@@ -112,7 +115,8 @@ define(function (require, exports, module) {
                         }
                     });
                 }
-                read(folder.createReader())
+
+                read(folder.createReader());
             }
 
             FileSystem.getDirectoryForPath(path).create(function(err) {

--- a/src/filesystem/impls/filer/lib/WebKitFileImport.js
+++ b/src/filesystem/impls/filer/lib/WebKitFileImport.js
@@ -292,7 +292,7 @@ define(function (require, exports, module) {
         }
     };
 
-    exports.create = function(byteLimit) {
-        return new WebKitFileImport(byteLimit);
+    exports.create = function(options) {
+        return new WebKitFileImport(options);
     };
 });

--- a/src/utils/DragAndDrop.js
+++ b/src/utils/DragAndDrop.js
@@ -38,24 +38,10 @@ define(function (require, exports, module) {
         FileUtils       = require("file/FileUtils"),
         ProjectManager  = require("project/ProjectManager"),
         Strings         = require("strings"),
-        StringUtils     = require("utils/StringUtils");
-
-    // Bramble specific bits
-    var _               = require("thirdparty/lodash"),
-        Filer           = require("filesystem/impls/filer/BracketsFiler"),
-        Path            = Filer.Path,
-        Content         = require("filesystem/impls/filer/lib/content"),
-        LanguageManager = require("language/LanguageManager"),
-        StartupState    = require("bramble/StartupState"),
-        ArchiveUtils    = require("filesystem/impls/filer/ArchiveUtils"),
-        FilerUtils      = require('filesystem/impls/filer/FilerUtils');
-
-    // 3MB size limit for imported files. If you change this, also change the
-    // error message we generate in rejectImport() below!
-    var byteLimit = 3145728;
-
-    // 5MB size limit for imported archives (zip & tar)
-    var archiveByteLimit = 5242880;
+        StringUtils     = require("utils/StringUtils"),
+        // XXXBramble specific bits
+        FileImport      = require("filesystem/impls/filer/lib/FileImport"),
+        FileSystemCache = require("filesystem/impls/filer/FileSystemCache");
 
     /**
      * Returns true if the drag and drop items contains valid drop objects.
@@ -63,15 +49,49 @@ define(function (require, exports, module) {
      * @return {boolean} True if one or more items can be dropped.
      */
     function isValidDrop(types) {
+        var i = 0;
+        var type;
+        console.log("Types", types);
+
         if (types) {
             for (var i = 0; i < types.length; i++) {
-                if (types[i] === "Files") {
+                // Safari uses 'public.file-url', Mozilla recommends 'application/x-moz-file',
+                // everyone else seems to use 'Files', accept any.
+                type = types[i];
+                if (type === "Files"               ||
+                    type === "public.file-url"     ||
+                    type === "application/x-moz-file") {
                     return true;
                 }
-
             }
         }
         return false;
+    }
+
+    /**
+     * Determines if the event contains a type list that has a URI-list.
+     * If it does and contains an empty file list, then what is being dropped is a URL.
+     * If that is true then we stop the event propagation and default behavior to save Brackets editor from the browser taking over.
+     * @param {Array.<File>} files Array of File objects from the event datastructure. URLs are the only drop item that would contain a URI-list.
+     * @param {event} event The event datastucture containing datatransfer information about the drag/drop event. Contains a type list which may or may not hold a URI-list depending on what was dragged/dropped. Interested if it does.
+     */
+    function stopURIListPropagation(event) {
+        var files = event.dataTransfer.files;
+        var types = event.dataTransfer.types;
+
+        if ((!files || !files.length) && types) { // We only want to check if a string of text was dragged into the editor
+            types.forEach(function (value) {
+                //Draging text externally (dragging text from another file): types has "text/plain" and "text/html"
+                //Draging text internally (dragging text to another line): types has just "text/plain"
+                //Draging a file: types has "Files"
+                //Draging a url: types has "text/plain" and "text/uri-list" <-what we are interested in
+                if (value === "text/uri-list") {
+                    event.stopPropagation();
+                    event.preventDefault();
+                    return;
+                }
+            });
+        }
     }
 
     function _showErrorDialog(errorFiles, callback) {
@@ -159,10 +179,34 @@ define(function (require, exports, module) {
             return result.promise();
         }, false)
             .fail(function () {
-                _showErrorDialog(errorFiles);
+                function errorToString(err) {
+                    if (err === ERR_MULTIPLE_ITEMS_WITH_DIR) {
+                        return Strings.ERROR_MIXED_DRAGDROP;
+                    } else {
+                        return FileUtils.getFileErrorString(err);
+                    }
+                }
+
+                if (errorFiles.length > 0) {
+                    var message = Strings.ERROR_OPENING_FILES;
+
+                    message += "<ul class='dialog-list'>";
+                    errorFiles.forEach(function (info) {
+                        message += "<li><span class='dialog-filename'>" +
+                            StringUtils.breakableUrl(ProjectManager.makeProjectRelativeIfPossible(info.path)) +
+                            "</span> - " + errorToString(info.error) +
+                            "</li>";
+                    });
+                    message += "</ul>";
+
+                    Dialogs.showModalDialog(
+                        DefaultDialogs.DIALOG_ID_ERROR,
+                        Strings.ERROR_OPENING_FILE_TITLE,
+                        message
+                    );
+                }
             });
     }
-
 
     /**
      * Attaches global drag & drop handlers to this window. This enables dropping files/folders to open them, and also
@@ -191,9 +235,10 @@ define(function (require, exports, module) {
 
         function handleDragOver(event) {
             event = event.originalEvent || event;
+            stopURIListPropagation(event);
+
             event.stopPropagation();
             event.preventDefault();
-
             options.ondragover(event);
 
             var dropEffect =  "none";
@@ -212,26 +257,40 @@ define(function (require, exports, module) {
 
         function handleDrop(event) {
             event = event.originalEvent || event;
+            stopURIListPropagation(event);
+
             event.stopPropagation();
             event.preventDefault();
-
             options.ondrop(event);
 
-            var files = event.dataTransfer.files;
-            processFiles(files, function() {
-                options.onfilesdone();
-
-                if(options.autoRemoveHandlers) {
-                    var elem = options.elem;
-                    $(elem)
-                        .off("dragover", handleDragOver)
-                        .off("dragleave", handleDragLeave)
-                        .off("drop", handleDrop);
-
-                    elem.removeEventListener("dragover", codeMirrorDragOverHandler, true);
-                    elem.removeEventListener("dragleave", codeMirrorDragLeaveHandler, true);
-                    elem.removeEventListener("drop", codeMirrorDropHandler, true);
+            FileImport.import(event.dataTransfer, function(err, paths) {
+                if(err) {
+                    _showErrorDialog(err);
                 }
+
+                // Don't crash in legacy browsers if we rejected all paths (e.g., folder(s)).
+                paths = paths || [];
+
+                FileSystemCache.refresh(function(err) {
+                    if(err) {
+                        console.error("[Bramble] unable to refresh filesystem cache");
+                    }
+                    options.onfilesdone();
+
+                    if(options.autoRemoveHandlers) {
+                        var elem = options.elem;
+                        $(elem)
+                            .off("dragover", handleDragOver)
+                            .off("dragleave", handleDragLeave)
+                            .off("drop", handleDrop);
+
+                        elem.removeEventListener("dragover", codeMirrorDragOverHandler, true);
+                        elem.removeEventListener("dragleave", codeMirrorDragLeaveHandler, true);
+                        elem.removeEventListener("drop", codeMirrorDropHandler, true);
+                    }
+
+                    openDroppedFiles(paths);
+                });
             });
         }
 
@@ -265,199 +324,12 @@ define(function (require, exports, module) {
         options.elem.addEventListener("drop", codeMirrorDropHandler, true);
     }
 
-    // XXXBramble: given a list of dropped files, write them into the fs, unzipping zip files.
-    function processFiles(files, callback) {
-        var pathList = [];
-        var errorList = [];
-
-        if (!(files && files.length)) {
-            return callback();
-        }
-
-        function shouldOpenFile(filename, encoding) {
-            return Content.isImage(Path.extname(filename)) || encoding === "utf8";
-        }
-
-        function handleRegularFile(deferred, file, filename, buffer, encoding) {
-            file.write(buffer, {encoding: encoding}, function(err) {
-                if (err) {
-                    errorList.push({path: filename, error: "unable to write file: " + err.message || ""});
-                    deferred.reject(err);
-                    return;
-                }
-
-                // See if this file is worth trying to open in the editor or not
-                if(shouldOpenFile(filename, encoding)) {
-                    pathList.push(filename);
-                }
-
-                deferred.resolve();
-            });
-        }
-
-        function handleZipFile(deferred, file, filename, buffer, encoding) {
-            var basename = Path.basename(filename);
-
-            ArchiveUtils.unzip(buffer, function(err) {
-                if (err) {
-                    errorList.push({path: filename, error: Strings.DND_ERROR_UNZIP});
-                    deferred.reject(err);
-                    return;
-                }
-
-                Dialogs.showModalDialog(
-                    DefaultDialogs.DIALOG_ID_INFO,
-                    Strings.DND_SUCCESS_UNZIP_TITLE,
-                    StringUtils.format(Strings.DND_SUCCESS_UNZIP, basename)
-                ).getPromise().then(deferred.resolve, deferred.reject);
-            });
-        }
-
-        function handleTarFile(deferred, file, filename, buffer, encoding) {
-            var basename = Path.basename(filename);
-
-            ArchiveUtils.untar(buffer, function(err) {
-                if (err) {
-                    errorList.push({path: filename, error: Strings.DND_ERROR_UNTAR});
-                    deferred.reject(err);
-                    return;
-                }
-
-                Dialogs.showModalDialog(
-                    DefaultDialogs.DIALOG_ID_INFO,
-                    Strings.DND_SUCCESS_UNTAR_TITLE,
-                    StringUtils.format(Strings.DND_SUCCESS_UNTAR, basename)
-                ).getPromise().then(deferred.resolve, deferred.reject);
-            });
-        }
-
-        /**
-         * Determine whether we want to import this file at all.  If it's too large
-         * or not a mime type we care about, reject it.
-         */
-        function rejectImport(item) {
-            var ext = Path.extname(item.name);
-            var sizeLimit = Content.isArchive(ext) ? archiveByteLimit : byteLimit;
-            var sizeLimitMb = (sizeLimit / (1024 * 1024)).toString();
-
-            if (item.size > sizeLimit) {
-                return new Error(StringUtils.format(Strings.DND_MAX_SIZE_EXCEEDED, sizeLimitMb));
-            } 
-
-            // If we don't know about this language type, or the OS doesn't think
-            // it's text, reject it.
-            var languageIsSupported = !!LanguageManager.getLanguageForExtension(ext);
-            var typeIsText = Content.isTextType(item.type);
-
-            if (languageIsSupported || typeIsText) {
-                return null;
-            }
-            return new Error(Strings.DND_UNSUPPORTED_FILE_TYPE);
-        }
-
-        function prepareDropPaths(fileList) {
-            // Convert FileList object to an Array with all image files first, then CSS
-            // followed by HTML files at the end, since we need to write any .css, .js, etc.
-            // resources first such that Blob URLs can be generated for these resources
-            // prior to rewriting an HTML file.
-            function rateFileByType(filename) {
-                var ext = Path.extname(filename);
-
-                // We want to end up with: [images, ..., js, ..., css, html]
-                // since CSS can include images, and HTML can include CSS or JS.
-                // We also treat .md like an HTML file, since we render them.
-                if(Content.isHTML(ext) || Content.isMarkdown(ext)) {
-                    return 10;
-                } else if(Content.isCSS(ext)) {
-                    return 8;
-                } else if(Content.isImage(ext)) {
-                    return 1;
-                }
-                return 3;
-            }
-
-            return _.toArray(fileList).sort(function(a,b) {
-                a = rateFileByType(a.name);
-                b = rateFileByType(b.name);
-
-                if(a < b) {
-                    return -1;
-                }
-                if(a > b) {
-                    return 1;
-                }
-                return 0;
-            });
-        }
-
-        function maybeImportFile(item) {
-            var deferred = new $.Deferred();
-            var reader = new FileReader();
-
-            // Check whether we want to import this file at all before we start.
-            var wasRejected = rejectImport(item);
-            if (wasRejected) {
-                errorList.push({path: item.name, error: wasRejected.message});
-                deferred.reject(wasRejected);
-                return deferred.promise();
-            }
-
-            reader.onload = function(e) {
-                delete reader.onload;
-
-                var filename = Path.join(StartupState.project("root"), item.name);
-                var file = FileSystem.getFileForPath(filename);
-                var ext = Path.extname(filename);
-
-                // Create a Filer Buffer, and determine the proper encoding. We
-                // use the extension, and also the OS provided mime type for clues.
-                var buffer = new Filer.Buffer(e.target.result);
-                var utf8FromExt = Content.isUTF8Encoded(ext);
-                var utf8FromOS = Content.isTextType(item.type);
-                var encoding =  utf8FromExt || utf8FromOS ? 'utf8' : null;
-                if(encoding === 'utf8') {
-                    buffer = buffer.toString();
-                }
-
-                // Special-case .zip files, so we can offer to extract the contents
-                if(ext === ".zip") {
-                    handleZipFile(deferred, file, filename, buffer, encoding);
-                } else if(ext === ".tar") {
-                    handleTarFile(deferred, file, filename, buffer, encoding);
-                } else {
-                    handleRegularFile(deferred, file, filename, buffer, encoding);
-                }
-            };
-
-            // Deal with error cases, for example, trying to drop a folder vs. file
-            reader.onerror = function(e) {
-                delete reader.onerror;
-
-                errorList.push({path: item.name, error: e.target.error.message});
-                deferred.reject(e.target.error);
-            };
-            reader.readAsArrayBuffer(item);
-
-            return deferred.promise();
-        }
-
-        Async.doSequentially(prepareDropPaths(files), maybeImportFile, false)
-            .done(function() {
-                openDroppedFiles(pathList);
-                callback(null, pathList);
-            })
-            .fail(function() {
-                _showErrorDialog(errorList, function() {
-                    callback(errorList);
-                });
-            });
-    }
-
     CommandManager.register(Strings.CMD_OPEN_DROPPED_FILES, Commands.FILE_OPEN_DROPPED_FILES, openDroppedFiles);
 
     // Export public API
     exports.attachHandlers      = attachHandlers;
     exports.isValidDrop         = isValidDrop;
     exports.openDroppedFiles    = openDroppedFiles;
-    exports.processFiles        = processFiles;
+    // TODO: fix this to FileImport.import()
+    //exports.processFiles        = processFiles;
 });

--- a/src/utils/DragAndDrop.js
+++ b/src/utils/DragAndDrop.js
@@ -43,6 +43,10 @@ define(function (require, exports, module) {
         FileImport      = require("filesystem/impls/filer/lib/FileImport"),
         FileSystemCache = require("filesystem/impls/filer/FileSystemCache");
 
+    // If the user indicates they want to import files deep into the filetree
+    // this is the path they want to use as a parent dir root.
+    var _dropPathHint;
+
     /**
      * Returns true if the drag and drop items contains valid drop objects.
      * @param {Array.<DataTransferItem>} items Array of items being dragged
@@ -51,7 +55,6 @@ define(function (require, exports, module) {
     function isValidDrop(types) {
         var i = 0;
         var type;
-        console.log("Types", types);
 
         if (types) {
             for (var i = 0; i < types.length; i++) {
@@ -319,7 +322,10 @@ define(function (require, exports, module) {
      * and process them, such that they end
      */
     function processFiles(source, callback) {
-        FileImport.import(source, function(err, paths) {
+        FileImport.import(source, _dropPathHint, function(err, paths) {
+            // Reset drop path, until we get an explicit one set in future.
+            _dropPathHint = null;
+
             if(err) {
                 _showErrorDialog(err);
                 callback(err);
@@ -334,10 +340,18 @@ define(function (require, exports, module) {
         });
     }
 
+    /**
+     * Sets a path to a root dir to use for importing dropped paths (see FileTreeView.js)
+     */
+    function setDropPathHint(path) {
+        _dropPathHint = path;
+    }
+
     CommandManager.register(Strings.CMD_OPEN_DROPPED_FILES, Commands.FILE_OPEN_DROPPED_FILES, openDroppedFiles);
 
     // Export public API
     exports.attachHandlers      = attachHandlers;
     exports.isValidDrop         = isValidDrop;
     exports.openDroppedFiles    = openDroppedFiles;
+    exports.setDropPathHint     = setDropPathHint;
 });

--- a/src/utils/DragAndDrop.js
+++ b/src/utils/DragAndDrop.js
@@ -263,7 +263,15 @@ define(function (require, exports, module) {
             event.preventDefault();
             options.ondrop(event);
 
-            FileImport.import(event.dataTransfer, function(err, paths) {
+            processFiles(event.dataTransfer, function(err) {
+                if(err) {
+                    console.log("[Bramble] error handling dropped files", err);
+                }
+            });
+        }
+
+        function processFiles(source, callback) {
+            FileImport.import(source, function(err, paths) {
                 if(err) {
                     _showErrorDialog(err);
                 }
@@ -290,6 +298,8 @@ define(function (require, exports, module) {
                     }
 
                     openDroppedFiles(paths);
+
+                    callback(err);
                 });
             });
         }

--- a/src/utils/DragAndDrop.js
+++ b/src/utils/DragAndDrop.js
@@ -82,7 +82,7 @@ define(function (require, exports, module) {
         var files = event.dataTransfer.files;
         var types = event.dataTransfer.types;
 
-        if ((!files || !files.length) && types) { // We only want to check if a string of text was dragged into the editor
+        if ( !(files && files.length) && types ) { // We only want to check if a string of text was dragged into the editor
             types.forEach(function (value) {
                 //Draging text externally (dragging text from another file): types has "text/plain" and "text/html"
                 //Draging text internally (dragging text to another line): types has just "text/plain"
@@ -350,6 +350,7 @@ define(function (require, exports, module) {
     CommandManager.register(Strings.CMD_OPEN_DROPPED_FILES, Commands.FILE_OPEN_DROPPED_FILES, openDroppedFiles);
 
     // Export public API
+    exports.processFiles        = processFiles;
     exports.attachHandlers      = attachHandlers;
     exports.isValidDrop         = isValidDrop;
     exports.openDroppedFiles    = openDroppedFiles;


### PR DESCRIPTION
I saw this tweet yesterday about CodePen's ability to let you drag and drop folders as well as files:

https://twitter.com/CodePen/status/843908650997600256?s=03

When I wrote our drag and drop stuff, browsers only supported files.  So I did some research, and sure enough, Edge, Chrome, and Firefox all support it (hilariously, all via a `webkit*` prefix method).  The drag and drop and file api specs are a bit of a dog's breakfast, however, I was able to make it all work.

With this patch, I've reworked our code to support both the new `webkit` way (which supports folders and files) and also the old way, which only works with folders.  Both ways still support auto-expanding of `.zip` and `.tar` files contained within.

I could use some help really testing this on various browsers and files/folders.  cc @Pomax and @flukeout.