### PR TITLE
Explain available copy/cut/paste options better

### DIFF
--- a/src/base-config/keyboard.json
+++ b/src/base-config/keyboard.json
@@ -34,15 +34,6 @@
             "platform": "mac"
         }
     ],
-    "edit.cut": [
-        "Ctrl-X"
-    ],
-    "edit.copy": [
-        "Ctrl-C"
-    ],
-    "edit.paste": [
-        "Ctrl-V"
-    ],
     "edit.selectAll":  [
         "Ctrl-A"
     ],

--- a/src/command/DefaultMenus.js
+++ b/src/command/DefaultMenus.js
@@ -253,6 +253,11 @@ define(function (require, exports, module) {
         // editor_cmenu.addMenuItem(Commands.NAVIGATE_JUMPTO_DEFINITION);
         editor_cmenu.addMenuItem(Commands.TOGGLE_QUICK_EDIT);
         editor_cmenu.addMenuItem(Commands.TOGGLE_QUICK_DOCS);
+        editor_cmenu.addMenuDivider();
+        editor_cmenu.addMenuItem(Commands.EDIT_CUT);
+        editor_cmenu.addMenuItem(Commands.EDIT_COPY);
+        editor_cmenu.addMenuItem(Commands.EDIT_PASTE);
+        editor_cmenu.addMenuDivider();
         editor_cmenu.addMenuItem(Commands.EDIT_SELECT_ALL);
 
         var inline_editor_cmenu = Menus.registerContextMenu(Menus.ContextMenuIds.INLINE_EDITOR_MENU);
@@ -281,18 +286,6 @@ define(function (require, exports, module) {
                     inlineWidget = EditorManager.getFocusedInlineWidget();
 
                 if (editor) {
-                    // If there's just an insertion point select the word token at the cursor pos so
-                    // it's more clear what the context menu applies to.
-                    if (!editor.hasSelection()) {
-                        editor.selectWordAt(editor.getCursorPos());
-
-                        // Prevent menu from overlapping text by moving it down a little
-                        // Temporarily backout this change for now to help mitigate issue #1111,
-                        // which only happens if mouse is not over context menu. Better fix
-                        // requires change to bootstrap, which is too risky for now.
-                        //e.pageY += 6;
-                    }
-
                     // Inline text editors have a different context menu (safe to assume it's not some other
                     // type of inline widget since we already know an Editor has focus)
                     if (inlineWidget) {

--- a/src/htmlContent/copy-paste-dialog.html
+++ b/src/htmlContent/copy-paste-dialog.html
@@ -1,0 +1,38 @@
+<div id="myModal" class="modal">
+  <!-- Modal content -->
+  <head>
+    <link rel="stylesheet" type="text/css" href="styles/bramble_overrides.css">
+  </head>
+  <div class="modal-content">
+    <span class="dialog-button" data-button-id="escape">&#10006;</span>
+    <h2 class="model-header">Copying and pasting in Thimble</h2>
+    <p class="model-text">
+      These actions are unavailable via the Edit menu, but you can still use:
+    </p>
+    <table class= "guide">
+      <tr>
+        <th>
+          {{{key}}}+X
+        </th>
+        <th>
+          {{{key}}}+C
+        </th>
+        <th>
+          {{{key}}}+V
+        </th>  
+      </tr>
+      <tr>
+        <td>
+          for copy
+        </td>
+        <td>
+          for cut
+        </td>
+        <td>
+          for paste
+        </td>
+      </tr>
+    </table>
+  </div>
+</div>
+

--- a/src/styles/bramble_overrides.css
+++ b/src/styles/bramble_overrides.css
@@ -72,6 +72,31 @@
     background: rgba(0, 135, 207, .3) !important;
 }
 
+table.guide {
+    width: 100%;
+}
+
+table.guide td{
+    text-align: center;
+    padding-bottom:20px;
+}
+
+.model-header {
+    padding-left:20px;
+}
+
+.model-text {
+    padding-left:20px;
+}
+
+span.dialog-button {
+    float: right;
+    padding-right: 10px;
+}
+
+.CodeMirror-lines {
+    padding-left: 10px;
+  
 .CodeMirror .CodeMirror-gutters .CodeMirror-gutter:after {
     display: none;
 }
@@ -86,13 +111,16 @@
     background: transparent !important;
 }
 
-
 /* Makes the resize handles wider, and visile on hover & drag */
 
 #sidebar {
   position: relative;
 }
 
+.CodeMirror-foldgutter:after {
+    display: none;
+}
+  
 .horz-resizer {
   transition: opacity .15s ease-out;
   background: rgba(0,0,0,.08);


### PR DESCRIPTION
implemented a check to see if browser supports these commands via queryCommandSupported if not display dialog which prompts users to use the native functionality for cut, copy, paste. The functionality also includes a check to see if the system is a mac and if so display command+c ..etc and if its not a mac, display Ctrl+c..etc.

fixes #451 