### PR TITLE
Fix #1306: Project rename input doesn't lose focus anymore 

### DIFF
--- a/src/document/DocumentCommandHandlers.js
+++ b/src/document/DocumentCommandHandlers.js
@@ -875,9 +875,6 @@ define(function (require, exports, module) {
         } else {
             result.resolve(file);
         }
-        result.always(function () {
-            MainViewManager.focusActivePane();
-        });
         return result.promise();
     }
 


### PR DESCRIPTION
Here is the fix for https://github.com/mozilla/thimble.mozilla.org/issues/1306.  Project rename input doesn't lose focus anymore when an auto-save is triggered