### PR TITLE
Fix #1907: menus don't have a dark theme anymore

### DIFF
--- a/src/view/ThemeManager.js
+++ b/src/view/ThemeManager.js
@@ -237,6 +237,7 @@ define(function (require, exports, module) {
                     return result.content;
                 })
                 .then(function (cssContent) {
+                    $("body").toggleClass("dark", theme.dark);
                     styleNode.text(cssContent);
                     $("body").attr('data-theme',theme.name);
                     pending.resolve(theme);


### PR DESCRIPTION
This fix fixes Thimble issue https://github.com/mozilla/thimble.mozilla.org/issues/1907

This line was erased in one of the previous PRs : $("body").toggleClass("dark", theme.dark);
Putting it back resolved the issue. I did some local testing to make sure nothing broke, everything seemed okay.