### PR TITLE
Turned of autoescaping in propeties2js.js

### DIFF
--- a/scripts/properties2js.js
+++ b/scripts/properties2js.js
@@ -48,7 +48,7 @@ var CONCURRENCY = { concurrency: 3 };
 var root = process.cwd();
 var src = path.join(root, "locales");
 var dest = path.join(root, process.argv.length > 2 ? process.argv[2] : "src", L10N_DIR);
-var templates = new Nunjucks.Environment(new Nunjucks.FileSystemLoader(path.join(root, "templates")));
+var templates = new Nunjucks.Environment(new Nunjucks.FileSystemLoader(path.join(root, "templates")), { autoescape: false });
 var destLocalizedStrings = {};
 var locales;
 var destLocales;

--- a/scripts/properties2js.js
+++ b/scripts/properties2js.js
@@ -53,6 +53,10 @@ var destLocalizedStrings = {};
 var locales;
 var destLocales;
 
+templates.addFilter('escapeQuotes', function(str){
+    return str.replace(/"/g, "&quot;");
+});
+
 function getDestLocaleDir(locale) {
     "use strict";
 

--- a/templates/strings.template
+++ b/templates/strings.template
@@ -4,6 +4,6 @@
 
 define({
 {% for key, string in localizedStrings %}
-    "{{ key }}": "{{ string | replace('\n', '\\n') }}"{{ "" if loop.last else "," }}
+    "{{ key }}": "{{ string | replace('\n', '\\n') | escapeQuotes }}"{{ "" if loop.last else "," }}
 {%- endfor %}
 });


### PR DESCRIPTION
Hello, 
Here is the link to the issue: https://github.com/mozilla/thimble.mozilla.org/issues/1833
Here how it looks now:
![screenshot from 2017-03-28 21-26-14](https://cloud.githubusercontent.com/assets/15698572/24468271/be50c224-1485-11e7-9c51-c543f4628055.png)
Basically, I just turned off auto escaping option right here: https://github.com/mozilla/brackets/blob/master/scripts/properties2js.js#L51
