### PR TITLE
Fix #673, Cancelling a file upload...

### DIFF
--- a/src/extensions/default/UploadFiles/UploadFilesDialog.js
+++ b/src/extensions/default/UploadFiles/UploadFilesDialog.js
@@ -177,7 +177,7 @@ define(function (require, exports, module) {
         if(_uploadDialog) {
            return _uploadDialog.deferred.promise();
         }
- 
+
         _uploadDialog = new FileUploadDialog();
         return _uploadDialog.show();
     }

--- a/src/extensions/default/UploadFiles/UploadFilesDialog.js
+++ b/src/extensions/default/UploadFiles/UploadFilesDialog.js
@@ -27,8 +27,10 @@ define(function (require, exports, module) {
     }(window.navigator));
 
     function FileInput() {
-        $(document.body)
-            .append($('<input class="upload-files-input-elem" type="file" multiple />'));
+        if (!$(".upload-files-input-elem")[0]){
+            $(document.body)
+                .append($('<input class="upload-files-input-elem" type="file" multiple />'));
+        }
     }
     FileInput.prototype.getFiles = function() {
         return this.getElem$()[0].files;
@@ -141,6 +143,7 @@ define(function (require, exports, module) {
         var deferred = self.deferred;
 
         self.hide();
+        _uploadDialog = null;
 
         function _processFiles(e) {
             var files = self.fileInput.getFiles();
@@ -174,7 +177,7 @@ define(function (require, exports, module) {
         if(_uploadDialog) {
            return _uploadDialog.deferred.promise();
         }
-
+        
         _uploadDialog = new FileUploadDialog();
         return _uploadDialog.show();
     }

--- a/src/extensions/default/UploadFiles/UploadFilesDialog.js
+++ b/src/extensions/default/UploadFiles/UploadFilesDialog.js
@@ -177,7 +177,7 @@ define(function (require, exports, module) {
         if(_uploadDialog) {
            return _uploadDialog.deferred.promise();
         }
-        
+ 
         _uploadDialog = new FileUploadDialog();
         return _uploadDialog.show();
     }


### PR DESCRIPTION
Fixes issue #673 

As discussed in #673 adding only `_uploadDialog = null`, i thought it fixed the problem.

However it would cause multiple `input` lines to be inserted for each time we clicked cancel.
<img width="438" alt="screen shot 2017-04-03 at 8 13 57 pm" src="https://cloud.githubusercontent.com/assets/11877279/24637404/f649c3a6-18ae-11e7-8895-3f5b358364d8.png">
So it would prompt n+1 for each input statements. 

To fix that I checked if the class `upload-files-input-elem` is already there or not. If its there don't append else append.

Results:
![ezgif-2-402a568712](https://cloud.githubusercontent.com/assets/11877279/24637681/052a7a94-18b1-11e7-904c-df6fab727d9e.gif)
