### PR TITLE
Fix #1934: Removed filename from Image Viewer and added some small tweaks

### DIFF
--- a/locales/en-US/editor.properties
+++ b/locales/en-US/editor.properties
@@ -136,6 +136,9 @@ DND_SUCCESS_UNZIP=Successfully unzipped <b>{0}</b>.
 # {0} will be replaced by a tar filename
 DND_SUCCESS_UNTAR=Successfully untarred <b>{0}</b>.
 
+# Image Viewer
+IMAGE_DIMENSIONS={0} (width) &times; {1} (height) pixels
+
 ################
 ## EXTENSIONS ##
 ################

--- a/src/editor/ImageViewer.js
+++ b/src/editor/ImageViewer.js
@@ -151,7 +151,9 @@ define(function (require, exports, module) {
         this._naturalHeight = e.currentTarget.naturalHeight;
 
         var extension = FileUtils.getFileExtension(this.file.fullPath);
-        var dimensionString = this._naturalWidth + " (width) &times; " + this._naturalHeight + " (height) " + Strings.UNIT_PIXELS;
+
+        var stringFormat = Strings.IMAGE_DIMENSIONS;
+        var dimensionString = StringUtils.format(stringFormat, this._naturalWidth, this._naturalHeight);
 
         if (extension === "ico") {
             dimensionString += " (" + Strings.IMAGE_VIEWER_LARGEST_ICON + ")";
@@ -170,9 +172,7 @@ define(function (require, exports, module) {
                 }
                 var dimensionAndSize = dimensionString + sizeString;
                 self.$imageData.html(dimensionAndSize)
-                        .attr("title", dimensionAndSize
-                                    .replace("&times;", "x")
-                                    .replace("&mdash;", "-"));
+                .attr("title", dimensionAndSize.replace("&mdash;", "-"));
             }
         });
 

--- a/src/editor/ImageViewer.js
+++ b/src/editor/ImageViewer.js
@@ -114,7 +114,6 @@ define(function (require, exports, module) {
 
         this.$image = this.$el.find(".image");
         this.$imageScale = this.$el.find(".image-scale");
-        this.$imagePath.text(this.relPath).attr("title", this.relPath);
         this.$imagePreview.on("load", _.bind(this._onImageLoaded, this));
 
         _viewers[file.fullPath] = this;
@@ -136,7 +135,6 @@ define(function (require, exports, module) {
          */
         if (this.file.fullPath === newPath) {
             this.relPath = ProjectManager.makeProjectRelativeIfPossible(newPath);
-            this.$imagePath.text(this.relPath).attr("title", this.relPath);
         }
     };
 
@@ -153,7 +151,7 @@ define(function (require, exports, module) {
         this._naturalHeight = e.currentTarget.naturalHeight;
 
         var extension = FileUtils.getFileExtension(this.file.fullPath);
-        var dimensionString = this._naturalWidth + " &times; " + this._naturalHeight + " " + Strings.UNIT_PIXELS;
+        var dimensionString = this._naturalWidth + " (width) &times; " + this._naturalHeight + " (height) " + Strings.UNIT_PIXELS;
 
         if (extension === "ico") {
             dimensionString += " (" + Strings.IMAGE_VIEWER_LARGEST_ICON + ")";
@@ -317,7 +315,7 @@ define(function (require, exports, module) {
      * Refreshes the image preview with what's on disk
      */
     ImageView.prototype.refresh = function () {
-        // Update the DOM node with the src URL 
+        // Update the DOM node with the src URL
         this.$imagePreview.attr("src", _getImageUrl(this.file));
     };
 

--- a/src/extensions/default/bramble/stylesheets/darkTheme.css
+++ b/src/extensions/default/bramble/stylesheets/darkTheme.css
@@ -63,6 +63,9 @@
   color: #F8F8F2;
   transition: background-color 0.3s ease-out;
 }
+.image-view {
+  background: #222;
+}
 .CodeMirror {
   border-left-color: #1B1B1B;
 }

--- a/src/styles/brackets.less
+++ b/src/styles/brackets.less
@@ -387,6 +387,7 @@ a, img {
             width: 100%;
             height: 38px;
             margin-bottom: 15px;
+            font-family: "Open Sans", "Helvetica Neue", sans-serif;
         }
 
         .image-data,


### PR DESCRIPTION
Here is my fix of this [issue](https://github.com/mozilla/thimble.mozilla.org/issues/1934). 
1. Viewer doesn't show filename anymore (even after we rename the file afterwards)
2. Width and Height labels are included
3. The font of the viewer is changed to Open Sans
4. The background colour of the viewer is changed to #222 when we use dark theme

![fixbug](https://cloud.githubusercontent.com/assets/13225708/24714657/197ab440-19f7-11e7-9918-74ec86283321.gif)
