### PR TITLE
Add brackets.env for runtime info on dev vs prod environment

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -227,6 +227,11 @@ module.exports = function (grunt) {
                     // `name` and `out` is set by grunt-usemin
                     baseUrl: 'src',
                     optimize: 'uglify2',
+                    paths: {
+                        // In various places in the code, it's useful to know if this is a dev vs. prod env.
+                        // See src/main.js default dev loading in src/ builds.
+                        "envConfig": "bramble/config/config.prod"
+                    },
                     // brackets.js should not be loaded until after polyfills defined in "utils/Compatibility"
                     // so explicitly include it in main.js
                     include: [

--- a/src/bramble/config/config.dev.js
+++ b/src/bramble/config/config.dev.js
@@ -1,0 +1,4 @@
+// Indicate that we're running in a development environment
+define({
+    "env": "development"
+});

--- a/src/bramble/config/config.prod.js
+++ b/src/bramble/config/config.prod.js
@@ -1,0 +1,4 @@
+// Indicate that we're running in a production environment
+define({
+    "env": "production"
+});

--- a/src/main.js
+++ b/src/main.js
@@ -35,7 +35,11 @@ require.config({
 
         // The file system implementation. Change this value to use different
         // implementations (e.g. cloud-based storage).
-        "fileSystemImpl"    : "filesystem/impls/filer/FilerFileSystem"
+        "fileSystemImpl"    : "filesystem/impls/filer/FilerFileSystem",
+
+        // In various places in the code, it's useful to know if this is a dev vs. prod env.
+        // See Gruntfile for prod override of this to config.prod.js.
+        "envConfig"         : "bramble/config/config.dev"
     },
     map: {
         "*": {

--- a/src/utils/Global.js
+++ b/src/utils/Global.js
@@ -32,7 +32,8 @@ define(function (require, exports, module) {
 
     var configJSON      = require("text!config.json"),
         UrlParams       = require("utils/UrlParams").UrlParams,
-        Compatibility   = require("utils/Compatibility");
+        Compatibility   = require("utils/Compatibility"),
+        envConfig       = require("envConfig");
 
     // Define core brackets namespace if it isn't already defined
     //
@@ -78,6 +79,9 @@ define(function (require, exports, module) {
     }
 
     global.brackets.inBrowser = !global.brackets.hasOwnProperty("fs");
+
+    // Specify whether this is a prod or dev environment for various runtime optimizations.
+    global.brackets.env = envConfig.env;
 
     // Are we in a desktop shell with a native menu bar?
     var hasNativeMenus = params.get("hasNativeMenus");


### PR DESCRIPTION
For doing some runtime optimizations (e.g., loading precompiled CSS vs. LESS in extensions) I need to know if the app is running in development or production mode.  This adds `brackets.env` so that any code can figure out which one we're running under, and make various choices.