### PR TITLE
Add Bramble events for service worker installation and updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,15 @@ mode, the filesystem (i.e., IndexedDB) will be inaccessible, and an error
 will be sent via the `error` event (i.e., `err.code === "EFILESYSTEMERROR"`).  This
 is the same error that occurs when the filesystem is corrupt (see `autoRecoverFileSystem` below).
 
+## Bramble Offline Support
+
+The Bramble code is offline capable, and will indicate, via events, when it is ready to be used offline, as well as
+when there are updates available for existing offline cached resources. These events are triggered on `Bramble` vs.
+the `bramble` instance.  The offline related events include:
+
+* `"offlineReady"` - triggered when Bramble has been fully cached for offline use.  Users can safely work without network.
+* `"updatesAvailable"` - triggered when new or updated Bramble resources have been cached and are available for use. You might use this to indicate to the user that they should refresh the page to begin using the updates.
+
 ## Bramble.getFileSystem()
 
 The FileSystem is owned by the hosting application, and can be obtained at any time by calling:

--- a/src/bramble/client/main.js
+++ b/src/bramble/client/main.js
@@ -231,7 +231,18 @@ define([
             addEventListener("message", function(e) {
                 var data = parseEventData(e.data);
 
-                // When Bramble is ready for the filesystem to be mounted, it will let us know
+                // Deal with messages from the service worker regarding cache. We trigger these
+                // events on Bramble vs. the bramble instance.
+                if(data.type === "Bramble:updatesAvailable") {
+                    Bramble.trigger("updatesAvailable");
+                    return;
+                }
+                if(data.type === "Bramble:offlineReady") {
+                    Bramble.trigger("offlineReady");
+                    return;
+                }
+
+                // When bramble instance is ready for the filesystem to be mounted, it will let us know
                 if (data.type === "bramble:readyToMount") {
                     debug("bramble:readyToMount");
                     setReadyState(Bramble.MOUNTABLE);

--- a/src/hosted.js
+++ b/src/hosted.js
@@ -114,6 +114,14 @@
             console.log("Bramble readyStateChange", previous, current);
         });
 
+        Bramble.on("offlineReady", function() {
+            console.log("Bramble available for offline use.");
+        });
+
+        Bramble.on("updatesAvailable", function() {
+            console.log("Bramble offline content updated, please refresh to use.");
+        });
+
         // Setup the filesystem while Bramble is loading
         ensureFiles(Bramble, function() {
             // Now that fs is setup, tell Bramble which root dir to mount

--- a/src/main.js
+++ b/src/main.js
@@ -78,6 +78,20 @@ if ('serviceWorker' in window.navigator) {
     window.navigator.serviceWorker.register('bramble-sw.js').then(function(reg) {
         "use strict";
 
+        function sendMessage(data) {
+            parent.postMessage(JSON.stringify(data), "*");
+        }
+
+        // Let the parent frame know that we have updates in the SW cache.
+        function updatesAvailable() {
+            sendMessage({ type: 'Bramble:updatesAvailable' });
+        }
+
+        // Let the parent frame know that we've cached content for offline loading.
+        function offlineReady() {
+            sendMessage({ type: 'Bramble:offlineReady' });
+        }
+
         reg.onupdatefound = function() {
             var installingWorker = reg.installing;
 
@@ -85,15 +99,9 @@ if ('serviceWorker' in window.navigator) {
                 switch (installingWorker.state) {
                 case 'installed':
                     if (window.navigator.serviceWorker.controller) {
-                        // At this point, the old content will have been purged and the fresh content will
-                        // have been added to the cache.
-                        // It's the perfect time to display a "New content is available; please refresh."
-                        // message in the page's interface.
-                        console.log('[Bramble] New or updated content is available.');
+                        updatesAvailable();
                     } else {
-                        // At this point, everything has been precached.
-                        // It's the perfect time to display a "Content is cached for offline use." message.
-                        console.log('[Bramble] Content is now available offline!');
+                        offlineReady();
                     }
                     break;
                 case 'redundant':


### PR DESCRIPTION
In Thimble I want to add UX to tell the user when there are SW cache updates, and the app needs to be refreshed, see https://github.com/mozilla/thimble.mozilla.org/issues/1930.  This PR adds two new events to the Bramble API for offline info.  I've also added them to `hosted.js` so we have a demo of how to use them.