### PR TITLE
Issue# 1596: Added the ability to add a tutorial after it has been removed

### DIFF
--- a/src/bramble/client/main.js
+++ b/src/bramble/client/main.js
@@ -753,8 +753,8 @@ define([
                             return shell.rm(path, genericFileEventFn("fileDelete", path, function(err) {
                             	var wrappedCallback = callback;
                             	if(!err && path === self.tutorialPath) {
-                            		wrappedCallback = genericFileEventFn("tutorialRemoved", path, wrappedCallback);
-                            		_tutorialExists = false;
+                            	   wrappedCallback = genericFileEventFn("tutorialRemoved", path, wrappedCallback);
+                            	   _tutorialExists = false;
                             	}
                             	wrappedCallback(err);
                             }));

--- a/src/bramble/client/main.js
+++ b/src/bramble/client/main.js
@@ -750,7 +750,14 @@ define([
                         // If the path was a file, immediately unlink
                         // trigger the event, and call the callback
                         if(err.code === "ENOTDIR") {
-                            return shell.rm(path, genericFileEventFn("fileDelete", path, callback));
+                            return shell.rm(path, genericFileEventFn("fileDelete", path, function(err) {
+                            	var wrappedCallback = callback;
+                            	if(!err && path === self.tutorialPath) {
+                            		wrappedCallback = genericFileEventFn("tutorialRemoved", path, wrappedCallback);
+                            		_tutorialExists = false;
+                            	}
+                            	wrappedCallback(err);
+                            }));
                         }
 
                         return callback(err);


### PR DESCRIPTION
This is the issue that I fixed: https://github.com/mozilla/thimble.mozilla.org/issues/1596
I followed the advice on fixing the bug, and simply added the code from the unlink case to the rm case. 
Here is the result:
![image](https://cloud.githubusercontent.com/assets/15698572/23285627/737aa4a8-fa00-11e6-8c84-0613e1143b59.png)
![image](https://cloud.githubusercontent.com/assets/15698572/23285641/874ce3e2-fa00-11e6-8502-e6e2c47e2574.png)
