### PR TITLE
Fix #684: minify all *.js in dist/

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -71,27 +71,9 @@ module.exports = function (grunt) {
             dist: {
                 files: [{
                     expand: true,
-                    cwd: 'src/',
-                    src: [
-                        /* static files */
-                        'xorigin.js',
-                        'dependencies.js',
-
-                        /* extensions and CodeMirror modes */
-                        '!extensions/**/*',
-                        '!**/unittest-files/**',
-                        'thirdparty/i18n/*.js',
-                        'thirdparty/text/*.js'
-                    ],
+                    cwd: 'dist/',
+                    src: '**/*.js',
                     dest: 'dist/'
-                }]
-            },
-            nls: {
-                files: [{
-                    expand: true,
-                    cwd: 'dist/nls',
-                    src: [ '**/*.js' ],
-                    dest: 'dist/nls'
                 }]
             }
         },

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
         "grunt-contrib-jasmine": "0.4.2",
         "grunt-contrib-less": "1.4.0",
         "grunt-contrib-requirejs": "0.4.1",
-        "grunt-contrib-uglify": "2.1.0",
+        "grunt-contrib-uglify": "^2.3.0",
         "grunt-contrib-watch": "0.4.3",
         "grunt-eslint": "18.1.0",
         "grunt-exec": "^1.0.1",


### PR DESCRIPTION
This depends on my other `default-extensions-only` branch landing first, then I need to rebase.  Now that we are only copying files we use to `dist/` it's safe to just minify all `*.js` in there, which reduces the size of extension files too. 