### PR TITLE
Updated README with missing Allow JS docs and some minor spelling fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ After you have everything setup, you can now run the server you chose in the roo
 
 # Bramble IFrame API
 
-Bramble is desinged to be run in an iframe, and the hosting web app to communicate with it
+Bramble is designed to be run in an iframe, and the hosting web app to communicate with it
 via `postMessage` and `MessageChannel`.  In order to simplify this, a convenience API exists
 for creating and managing the iframe, as well as providing JavaScript functions for interacting
 with the editor, preview, etc.
@@ -268,6 +268,7 @@ a number of read-only getters are available in order to access state information
 * `getTheme()` - returns the name of the current theme.
 * `getFontSize()` - returns the current font size as a string (e.g., `"12px"`).
 * `getWordWrap()` - returns the current word wrap setting as a `Boolean` (i.e., enabled or disabled).
+* `getAllowJavaScript()` - returns the current allow javascript setting as a `Boolean` (i.e., enabled or disabled).
 * `getAutocomplete()` - returns the current autocomplete settings as a `Boolean` (i.e., enabled or disabled).
 * `getAutoCloseTags()` - returns the current close tags setting as an `Object` with three properties: `whenOpening` a boolean that determines whether opening tags are closed upon typing ">", `whenClosing` a boolean that determines whether closing tags are closed upon typing "/", and an array of tags `indentTags`, that when opened, has a blank line. These values default to, respectively: `true`, `true`, and an empty array.
 * `getTutorialExists()` - returns `true` or `false` depending on whether or not there is a tutorial in the project (i.e., if `tutorial.html` is present)
@@ -286,7 +287,7 @@ to be notified when the action completes:
 * `undo([callback])` - undo the last operation in the editor (waits for focus)
 * `redo([callback])` - redo the last operation that was undone in the editor (waits for focus)
 * `increaseFontSize([callback])` - increases the editor's font size
-* `decreaseFontSize([callback])` - decreases the edtior's font size
+* `decreaseFontSize([callback])` - decreases the editor's font size
 * `restoreFontSize([callback])` - restores the editor's font size to normal
 * `save([callback])` - saves the current document
 * `saveAll([callback])` - saves all "dirty" documents
@@ -306,7 +307,7 @@ to be notified when the action completes:
 * `useMobilePreview([callback])` - uses a Mobile view in the preview, as it would look on a smartphone
 * `useDesktopPreview([callback])` - uses a Desktop view in the preview, as it would look on a desktop computer (default)
 * `enableFullscreenPreview([callback])` - shows a fullscreen preview of the current file
-* `disableFullscreenPreview([callback])` - turns off the fullscreen preview of the curent file
+* `disableFullscreenPreview([callback])` - turns off the fullscreen preview of the current file
 * `enableAutoUpdate([callback])` - turns on auto-update for the preview (default)
 * `disableAutoUpdate([callback])` - turns off auto-update for the preview (manual reloads still work)
 * `enableJavaScript([callback])` - turns on JavaScript execution for the preview (default)
@@ -329,13 +330,14 @@ to be notified when the action completes:
 The Bramble instance is also an [`EventEmitter`](https://github.com/Wolfy87/EventEmitter/) and raises
 the following events:
 
-* `"layout"` - triggered whenever the sidebar, editor, or preview panes are changed. It includes an `Object` that returns the same infor as the `getLayout()` getter: : `sidebarWidth`, `firstPaneWidth`, `secondPathWidth`
+* `"layout"` - triggered whenever the sidebar, editor, or preview panes are changed. It includes an `Object` that returns the same information as the `getLayout()` getter: : `sidebarWidth`, `firstPaneWidth`, `secondPathWidth`
 * `"activeEditorChange"` - triggered whenever the editor changes from one file to another. It includes an `Object` with the current file's `fullPath` and `filename`.
 * `"previewModeChange"` - triggered whenever the preview mode is changed. It includes an `Object` with the new `mode`
 * `"sidebarChange"` - triggered whenever the sidebar is hidden or shown. It includes an `Object` with a `visible` property set to `true` or `false`
-* `"themeChange"` - triggered whenever the theme changes. It inclues an `Object` with a `theme` property that indicates the new theme
+* `"themeChange"` - triggered whenever the theme changes. It includes an `Object` with a `theme` property that indicates the new theme
 * `"fontSizeChange"` - triggered whenever the font size changes. It includes an `Object` with a `fontSize` property that indicates the new size (e.g., `"12px"`).
 * `"wordWrapChange"` - triggered whenever the word wrap value changes. It includes an `Object` with a `wordWrap` property that indicates the new value (e.g., `true` or `false`).
+* `"allowJavaScriptChange"` - triggered whenever the allow javascript value changes. It includes an `Object` with a `allowJavaScript` property that indicates the new value (e.g., `true` or `false`).
 * `"autoCloseTagsChange"` - triggered whenever the close tag value changes. It includes an `Object` with a `autoCloseTags` property that indicates the new value
 * `"tutorialAdded"` - triggered when a new tutorial is added to the project
 * `"tutorialRemoved"` - triggered when an existing tutorial for the project is removed


### PR DESCRIPTION
I noticed some Allow JavaScript (toggle) docs were missing and I added them in. My spellchecker also caught some words. Not a big deal, but no harm in opening this PR.