### PR TITLE
Fix mozilla/thimble.mozilla.org#591: Close/reopen code hint bug

### DIFF
--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -808,7 +808,7 @@ define(function (require, exports, module) {
                 return w.info;
             });
         return (widgetInfo ? this._inlineWidgets[allWidgetInfos.indexOf(widgetInfo[0])] : null);
-    }
+    };
 
     /**
      * Determine the mode to use from the document's language

--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -797,6 +797,20 @@ define(function (require, exports, module) {
     };
 
     /**
+     * Grabs the widget assosiated with the lineNum
+     * @param {number} lineNum
+     * @return {?InlineWidget} Returns Inlinewidget if exists
+     */
+    Editor.prototype.getWidget = function(lineNum){
+        var lineInfo = this._codeMirror.lineInfo(lineNum),
+            widgetInfo = (lineInfo && lineInfo.widgets) ? [].concat(lineInfo.widgets) : null,
+            allWidgetInfos = this._inlineWidgets.map(function (w) {
+                return w.info;
+            });
+        return (widgetInfo ? this._inlineWidgets[allWidgetInfos.indexOf(widgetInfo[0])] : null);
+    }
+
+    /**
      * Determine the mode to use from the document's language
      * Uses "text/plain" if the language does not define a mode
      * @return {string} The mode to use
@@ -807,7 +821,6 @@ define(function (require, exports, module) {
         // here so we're always explicit, avoiding console noise.
         return this.document.getLanguage().getMode() || "text/plain";
     };
-
 
     /**
      * Selects all text and maintains the current scroll position.
@@ -1792,7 +1805,7 @@ define(function (require, exports, module) {
         return this._inlineWidgets;
     };
 
-      /**
+    /**
      * Returns the currently focused inline widget, if any.
      * @return {?InlineWidget}
      */

--- a/src/editor/EditorManager.js
+++ b/src/editor/EditorManager.js
@@ -294,11 +294,14 @@ define(function (require, exports, module) {
         var currentEditor = getCurrentFullEditor();
 
         if (currentEditor) {
-            var inlineWidget = currentEditor.getFocusedInlineWidget();
+            var curPos = currentEditor.getCursorPos();
+            var focusedWidget = currentEditor.getFocusedInlineWidget();
+            var inlineWidget = focusedWidget || currentEditor.getWidget(curPos.line);
 
             if (inlineWidget) {
                 // an inline widget's editor has focus, so close it
                 PerfUtils.markStart(PerfUtils.INLINE_WIDGET_CLOSE);
+                currentEditor.removeInlineWidget(inlineWidget);
                 inlineWidget.close().done(function () {
                     PerfUtils.addMeasurement(PerfUtils.INLINE_WIDGET_CLOSE);
                     // return a resolved promise to CommandManager

--- a/src/editor/EditorManager.js
+++ b/src/editor/EditorManager.js
@@ -295,13 +295,11 @@ define(function (require, exports, module) {
 
         if (currentEditor) {
             var curPos = currentEditor.getCursorPos();
-            var focusedWidget = currentEditor.getFocusedInlineWidget();
-            var inlineWidget = focusedWidget || currentEditor.getWidget(curPos.line);
-
+            var inlineWidget = currentEditor.getFocusedInlineWidget() || currentEditor.getWidget(curPos.line);
+            
             if (inlineWidget) {
                 // an inline widget's editor has focus, so close it
                 PerfUtils.markStart(PerfUtils.INLINE_WIDGET_CLOSE);
-                currentEditor.removeInlineWidget(inlineWidget);
                 inlineWidget.close().done(function () {
                     PerfUtils.addMeasurement(PerfUtils.INLINE_WIDGET_CLOSE);
                     // return a resolved promise to CommandManager


### PR DESCRIPTION
Fixed bug associated here:
mozilla/thimble.mozilla.org#591

Here's a demo:
![ezgif com-optimize](https://cloud.githubusercontent.com/assets/1103528/24824040/33a4cde6-1bd3-11e7-8287-4e832c4e393a.gif)

If the widget is opened, it will close it (Instead of reopening it). If you click on an opened widget and press `ALT + K`, then that widget will be closed.