### PR TITLE
Fix missing build step to copy image icons for filetree on build.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -121,7 +121,7 @@ module.exports = function (grunt) {
                         expand: true,
                         dest: 'dist/styles',
                         cwd: 'src/styles',
-                        src: ['jsTreeTheme.css', 'images/*', 'brackets.min.css*', 'bramble_overrides.css']
+                        src: ['jsTreeTheme.css', 'images/**/*', 'brackets.min.css*', 'bramble_overrides.css']
                     }
                 ]
             },


### PR DESCRIPTION
Follow-up to 04492ececee525ca994d596d9c0264d83e8914b2 and #660, we were only copying `src/styles/images/*` and when we introduced a new dir `icons` underneath that, we needed to update the glob pattern.  I've tested this locally and it works.