### PR TITLE
[WIP] Fix #700 Removed warning for deprecation, and removed brackets-paste-and-indent as a submodule

### DIFF
--- a/src/brackets.js
+++ b/src/brackets.js
@@ -317,10 +317,6 @@ define(function (require, exports, module) {
                 jQObject.off = firstArg.off.bind(firstArg);
                 // Don't offer legacy support for trigger()/triggerHandler() on core model objects; extensions
                 // shouldn't be doing that anyway since it's basically poking at private API
-
-                // Console warning, since $() is deprecated for EventDispatcher objects
-                // (pass true to only print once per caller, and index 4 since the extension caller is deeper in the stack than usual)
-                DeprecationWarning.deprecationWarning("Deprecated: Do not use $().on/off() on Brackets modules and model objects. Call on()/off() directly on the object without a $() wrapper.", true, 4);
             }
             return jQObject;
         };


### PR DESCRIPTION
I'm not entirely sure if I pushed the changes made in the brackets-paste-and-indent submodule. Perhaps someone can help me.

But what I did was remove the Deprecation warning for the use of $().on/off().
And in `brackets-paste-and-indent/main.js` I replaced the prior `currentDocumentChange` with `EditorManager.on("activeEditorChange", ...`