### PR TITLE
Force FileUtils.readAsText() to open files as utf8

### DIFF
--- a/src/file/FileUtils.js
+++ b/src/file/FileUtils.js
@@ -77,7 +77,7 @@ define(function (require, exports, module) {
         });
 
         // Read file
-        file.read(function (err, data, stat) {
+        file.read({encoding: "utf8"}, function (err, data, stat) {
             if (!err) {
                 result.resolve(data, stat.mtime);
             } else {


### PR DESCRIPTION
From https://github.com/mozilla/thimble.mozilla.org/pull/1970#issuecomment-293630778, @flukeout is hitting `text.substr` is not a function errors.  This is happening when trying to open an SVG file.  I think that this is caused by the mime type being an image, and therefore binary, when it should really be opening as text.  We've not hit this in the past because we didn't open SVG files as text.

I think this is a safe change, since `readText` assumes you want utf8.  @gideonthomas see if you agree.