### PR TITLE
Issue#696 Modified HTTP-server to link to the git repo gzip branch

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "devDependencies": {
         "bluebird": "^3.4.7",
         "gunzip-maybe": "^1.3.1",
-        "http-server": "^0.9.0",
+        "http-server" : "mozilla/http-server#gzip",
         "mkdirp": "0.5.1",
         "nunjucks": "^2.4.3",
         "properties-parser": "0.3.1",
@@ -64,7 +64,7 @@
         "postinstall": "grunt install",
         "build": "grunt build-browser",
         "preproduction": "grunt build-browser-compressed && grunt unlocalize",
-        "production": "npm start",
+        "production": "npm start -- --gzip",
         "unlocalize": "grunt unlocalize",
         "test": "grunt test && grunt build-browser-compressed",
         "start": "http-server -p 8000 --cors"

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "devDependencies": {
         "bluebird": "^3.4.7",
         "gunzip-maybe": "^1.3.1",
-        "http-server" : "mozilla/http-server#gzip",
+        "http-server": "mozilla/http-server#gzip",
         "mkdirp": "0.5.1",
         "nunjucks": "^2.4.3",
         "properties-parser": "0.3.1",


### PR DESCRIPTION
Fixes #696 

I changed the `npm start` to `npm start -- --gzip`

and changed `"http-server": "^0.9.0",` to `"http-server": "mozilla/http-server#gzip",`

You will be able to test it by running `Npm install`, and than  `npm run production`.
Once it says the server is up got to [http://localhost:8000/dist/hosted.html](http://localhost:8000/dist/hosted.html).

You should be able to see this:

![2350a204e6012bcc3e7ec604d611e79e](https://cloud.githubusercontent.com/assets/10540058/24989952/66f88e3a-1fde-11e7-9784-e1f0c64bdd9e.png)
