### PR TITLE
Use IE11 compliant Array and String calls

### DIFF
--- a/src/bramble/client/ProjectStats.js
+++ b/src/bramble/client/ProjectStats.js
@@ -28,7 +28,7 @@ define([
     ProjectStats.init = function(root, callback){
         function addSize(path, next){
             // ignore directories and do nothing
-            if (path.endsWith("/")){
+            if (/\/$/.test(path)){
                 return next();
             }
 

--- a/src/extensions/default/bramble/lib/ConsoleManagerRemote.js
+++ b/src/extensions/default/bramble/lib/ConsoleManagerRemote.js
@@ -17,13 +17,13 @@
      "time",
      "timeEnd"].forEach(function(type) {
         console[type] = function() {
-            var args = Array.from(arguments).slice();
+            var args = Array.prototype.slice.call(arguments);
             transportSend(type, args);
         };
     });
     
     console.assert = function() {
-        var args = Array.from(arguments).slice();
+        var args = Array.prototype.slice.call(arguments);
         var expr = args.shift();
         if (!expr) {
             args[0] = "Assertion Failed: " + args[0];


### PR DESCRIPTION
In looking at #598 on IE11, I notice that we recently introduced a few `String` and `Array` calls that aren't compatible with IE11.  This fixes them.

cc @dsych, @raygervais 

