### PR TITLE
Fix #Thimble-1928: fixed brackets URL hint to work with spaces in path names

### DIFF
--- a/src/extensions/default/BrambleUrlCodeHints/main.js
+++ b/src/extensions/default/BrambleUrlCodeHints/main.js
@@ -559,9 +559,6 @@ define(function (require, exports, module) {
         function insert(text) {
             var mode = that.editor.getModeForSelection();
 
-            // Encode the string just prior to inserting the hint into the editor
-            text = encodeURI(text);
-
             if (mode === "html") {
                 return that.insertHtmlHint(text);
             } else if (styleModes.indexOf(mode) > -1) {


### PR DESCRIPTION
This issue was noted in thimble repo. Just removed a single line in the code which encoded space (" ") and added %20 instead. Please take a look! 

Thank you 🐶 