### PR TITLE
Trigger Tutorial mode by default on project load. To Fix Thimble #1776

### DIFF
--- a/src/extensions/default/bramble/main.js
+++ b/src/extensions/default/bramble/main.js
@@ -123,7 +123,7 @@ define(function (require, exports, module) {
         RemoteEvents.loaded();
 
         // Show Tutorial Pane by default if `tutorial.html` exists at project load
-        // Can only be done after Remote Events is finished loadind so that thimble and bramble can communicate
+        // Can only be done after Remote Events is finished loading so that thimble and bramble can communicate
         var filename = BrambleStartupState.project("filename");
         if(Path.basename(filename) === "tutorial.html") {
             BrambleEvents.triggerTutorialVisibilityChange(true);

--- a/src/extensions/default/bramble/main.js
+++ b/src/extensions/default/bramble/main.js
@@ -15,6 +15,7 @@ define(function (require, exports, module) {
         PreferencesManager   = brackets.getModule("preferences/PreferencesManager"),
         LiveDevelopment      = brackets.getModule("LiveDevelopment/LiveDevMultiBrowser"),
         BrambleStartupState  = brackets.getModule("bramble/StartupState"),
+        BrambleEvents        = brackets.getModule("bramble/BrambleEvents"),
         ProjectManager       = brackets.getModule("project/ProjectManager"),
         CommandManager       = brackets.getModule("command/CommandManager"),
         Commands             = brackets.getModule("command/Commands"),
@@ -120,6 +121,13 @@ define(function (require, exports, module) {
 
         // We're all done loading and can pass startup state info back to the host app.
         RemoteEvents.loaded();
+
+        // Show Tutorial Pane by default if `tutorial.html` exists at project load
+        // Can only be done after Remote Events is finished loadind so that thimble and bramble can communicate
+        var filename = BrambleStartupState.project("filename");
+        if(Path.basename(filename) === "tutorial.html") {
+            BrambleEvents.triggerTutorialVisibilityChange(true);
+        }
     }
 
     // Normally, in Brackets proper, this happens in src/brackets.js. We've moved it here


### PR DESCRIPTION
As discussed in [Thimble #1776](https://github.com/mozilla/thimble.mozilla.org/issues/1776). 

Emits a `BrambleEvent` `bramble:tutorialVisibilityChange` when `tutorial.html` is the default file being previewed at project load. This switches the Preview Pane to the Tutorial Pane.