### PR TITLE
[WIP] Fix mozilla/thimble.mozilla.org#889: Remove root folder thimble-project if exists

### DIFF
--- a/src/filesystem/impls/filer/ArchiveUtils.js
+++ b/src/filesystem/impls/filer/ArchiveUtils.js
@@ -85,7 +85,7 @@ define(function (require, exports, module) {
                 }
 
                 var isDir = file.options.dir;
-                var filename = removeProjectFolder(file.name);
+                var filename = removeThimbleProjectFolder(file.name);
                 filenames.push({
                     absPath: Path.join(destination, filename),
                     isDirectory: isDir,
@@ -93,10 +93,10 @@ define(function (require, exports, module) {
                 });
             });
 
-            function removeProjectFolder(path){
-                // Nuke root folder thimble-project/ if exists
-                var regex = /^thimble\-project\//g;
-                return path.replace(regex, "");
+            function removeThimbleProjectFolder(path){
+                // Nuke root folder `thimble-project/` if exists so that project zip files
+                // can be re-imported without adding an unnecessary folder.
+                return path.replace(/^thimble\-project\//, "");
             }
 
             function decompress(path, callback) {

--- a/src/filesystem/impls/filer/ArchiveUtils.js
+++ b/src/filesystem/impls/filer/ArchiveUtils.js
@@ -85,12 +85,19 @@ define(function (require, exports, module) {
                 }
 
                 var isDir = file.options.dir;
+                var filename = removeProjectFolder(file.name);
                 filenames.push({
-                    absPath: Path.join(destination, file.name),
+                    absPath: Path.join(destination, filename),
                     isDirectory: isDir,
                     data: isDir ? null : new Buffer(file.asArrayBuffer())
                 });
             });
+
+            function removeProjectFolder(path){
+                // Nuke root folder thimble-project/ if exists
+                var regex = /^thimble\-project\//g;
+                return path.replace(regex, "");
+            }
 
             function decompress(path, callback) {
                 var basedir = Path.dirname(path.absPath);
@@ -152,7 +159,7 @@ define(function (require, exports, module) {
 
         function toRelProjectPath(path) {
             // Make path relative within the zip, rooted in a `project/` dir
-            return path.replace(rootRegex, "project/");
+            return path.replace(rootRegex, "thimble-project/");
         }
 
         function addFile(path, callback) {

--- a/src/filesystem/impls/filer/ArchiveUtils.js
+++ b/src/filesystem/impls/filer/ArchiveUtils.js
@@ -208,7 +208,7 @@ define(function (require, exports, module) {
 
             var compressed = jszip.generate({type: 'arraybuffer'});
             var blob = new Blob([compressed], {type: "application/zip"});
-            saveAs(blob, "project.zip");
+            saveAs(blob, "thimble-project.zip");
             callback();
         });
     }


### PR DESCRIPTION
The user is now able to export and import a zipped project without creating redundant folders (As first described here: mozilla/thimble.mozilla.org#889).

Because `ArchiveUtils.js` is being changed by @humphd, I've added the `[WIP]` in the title. Once his PR lands, I'll make the necessary changes 👍 