### PR TITLE
Fix mozilla/thimble.mozilla.org#1227 Fix UX & Errors when moving a file into a folder that already contains a file with that name.

### DIFF
--- a/src/extensions/default/bramble-move-file/MoveToDialog.js
+++ b/src/extensions/default/bramble-move-file/MoveToDialog.js
@@ -78,7 +78,7 @@ define(function (require, exports, module) {
         if(error.type === MoveUtils.NEEDS_RENAME) {
             Dialogs.showModalDialog(DefaultDialogs.DIALOG_ID_ERROR,
                 Strings.ERROR_MOVING_FILE_DIALOG_HEADER,
-                StringUtils.format(Strings.ERROR_MOVING_FILE_SAME_NAME, from, to), false
+                StringUtils.format(Strings.ERROR_MOVING_FILE_SAME_NAME, from, to)
             );
             return;
         }

--- a/src/extensions/default/bramble-move-file/MoveToDialog.js
+++ b/src/extensions/default/bramble-move-file/MoveToDialog.js
@@ -78,7 +78,7 @@ define(function (require, exports, module) {
         if(error.type === MoveUtils.NEEDS_RENAME) {
             Dialogs.showModalDialog(DefaultDialogs.DIALOG_ID_ERROR,
                 Strings.ERROR_MOVING_FILE_DIALOG_HEADER,
-                StringUtils.format(Strings.ERROR_MOVING_FILE_SAME_NAME, from, to)
+                StringUtils.format(Strings.ERROR_MOVING_FILE_SAME_NAME, from, to), false
             );
             return;
         }
@@ -114,9 +114,7 @@ define(function (require, exports, module) {
             MoveUtils.move(source, destination)
             .done(_finishMove.bind(null, source, destination))
             .fail(_failMove.bind(null, source, destination))
-            .always(function() {
-                dialog.close();
-            });
+            .then(dialog.close());
         });
     }
 


### PR DESCRIPTION
Fix mozilla/thimble.mozilla.org#1227 

This will fix the issue of the file tree being frozen when moving a file to a folder that already contains a file with that name. The error dialog actually does show up but because we [always](https://github.com/mozilla/brackets/blob/master/src/extensions/default/bramble-move-file/MoveToDialog.js#L117) close the dialog even when it fails, we never have a chance to see it.

The solution here is instead of always calling the `dialog.close()` command, now it should only be called when the file has successfully moved. If it fails, the error dialog can dismiss itself since it has [this feature](https://github.com/mozilla/brackets/blob/master/src/widgets/Dialogs.js#L392). 

