### PR TITLE
Fix https://github.com/mozilla/thimble.mozilla.org/issues/2004: dist/builds have proper CSS again

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -111,7 +111,6 @@ module.exports = function (grunt) {
                             '!filesystem/impls/appshell/**/*',
                             // We deal with extensions dynamically below in build-extensions
                             '!extensions/**/*',
-                            'thirdparty/CodeMirror/lib/codemirror.css',
                             'thirdparty/i18n/*.js',
                             'thirdparty/text/*.js'
                         ]
@@ -121,7 +120,7 @@ module.exports = function (grunt) {
                         expand: true,
                         dest: 'dist/styles',
                         cwd: 'src/styles',
-                        src: ['jsTreeTheme.css', 'images/**/*', 'brackets.min.css*']
+                        src: ['jsTreeTheme.css', 'images/**/*']
                     }
                 ]
             },


### PR DESCRIPTION
This seems to fix things for me.  To test, `npm start` and try a `src/` build.  Make sure the editor looks right.  Next, `npm run build` and run in `dist/` (make sure you have your service worker wiped and cache off).  For me, both show the right stuff now. 