### PR TITLE
Don't error when running hosted.html require in dist/ vs. src/

### DIFF
--- a/src/hosted.js
+++ b/src/hosted.js
@@ -11,6 +11,8 @@
         baseUrl: './'
     });
 
+    var brambleModule;
+
     // Allow the user to override what we do with default files using `?forceFiles=1`
     var forceFiles = window.location.search.indexOf("forceFiles=1") > -1;
 
@@ -131,12 +133,15 @@
     }
 
     // Support loading from src/ or dist/ to make local dev easier
-    require(["bramble/client/main"], function(Bramble) {
+    if(window.location.pathname === "/dist/hosted.html") {
+        console.info("[Bramble] loading dist/ build.");
+        brambleModule = "bramble";
+    } else {
+        console.info("[Bramble] loading src/ build.");
+        brambleModule = "bramble/client/main";
+    }
+
+    require([brambleModule], function(Bramble) {
         load(Bramble);
-    }, function(err) {
-        console.log("Unable to load Bramble from src/, trying from dist/");
-        require(["bramble"], function(Bramble) {
-            load(Bramble);
-        });
     });
 }());


### PR DESCRIPTION
People constantly complain about the requirejs error we have when we load in `dist/`.  This doesn't rely on require to fail before trying to load in dist.  NOTE: this only affects `hosted.html` (so testing).