### PR TITLE
Fixes Issue #1974, Brackets doesn't highlight all the way across the filetree

### DIFF
--- a/src/styles/brackets_scrollbars.less
+++ b/src/styles/brackets_scrollbars.less
@@ -44,7 +44,7 @@
 .dark.platform-linux .quiet-scrollbars {
 
     ::-webkit-scrollbar {
-        width: 0px;
+        width: 0;
         height: 9px;
         background-color: transparent;
     }

--- a/src/styles/brackets_scrollbars.less
+++ b/src/styles/brackets_scrollbars.less
@@ -44,7 +44,7 @@
 .dark.platform-linux .quiet-scrollbars {
 
     ::-webkit-scrollbar {
-        width: 9px;
+        width: 0px;
         height: 9px;
         background-color: transparent;
     }


### PR DESCRIPTION
Fixes [#1974](https://github.com/mozilla/thimble.mozilla.org/issues/1974)
Changed the Width value in brackets_scrollbars.less.
![opensource](https://cloud.githubusercontent.com/assets/14276579/25204602/45ccd542-252c-11e7-8f3e-051aec6fb2ff.gif)
