### PR TITLE
Fix #721, https://github.com/mozilla/thimble.mozilla.org/issues/2005: bramble.less

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -167,7 +167,7 @@ module.exports = function (grunt) {
                     // XXXBramble: if you change this, change configureExtensions() below too.
                     "dist/styles/brackets.min.css": [
                         "src/thirdparty/CodeMirror/lib/codemirror.css",
-                        "src/styles/brackets.less"
+                        "src/styles/bramble.less"
                     ]
                 },
                 options: {

--- a/src/index.html
+++ b/src/index.html
@@ -105,7 +105,7 @@
 
     <!--(if target dev)><!-->
     <link rel="stylesheet" type="text/css" href="thirdparty/CodeMirror/lib/codemirror.css">
-    <link rel="stylesheet/less" type="text/css" href="styles/brackets.less">
+    <link rel="stylesheet/less" type="text/css" href="styles/bramble.less">
     <!--<!(endif)-->
     <!--(if target dist)>
     <link rel="stylesheet" type="text/css" href="styles/brackets.min.css">

--- a/src/styles/brackets_shared.less
+++ b/src/styles/brackets_shared.less
@@ -57,6 +57,3 @@
 
 // Styling for scrollbars
 @import url("brackets_scrollbars.less");
-
-// Thimble-specific overrides
-@import url("bramble_overrides.less");

--- a/src/styles/bramble.less
+++ b/src/styles/bramble.less
@@ -1,0 +1,11 @@
+/**
+ * This is the root CSS for Bramble.  It includes everything Brackets does
+ * as well as overrides specific to Bramble. Put your rules in bramble_overrides.less
+ * or create a new file and include it here.
+ */
+
+// Brackets root stylesheet
+@import url("brackets.less");
+
+// Thimble-specific overrides
+@import url("bramble_overrides.less");


### PR DESCRIPTION
This fixes our load ordering for LESS/CSS, such that our overrides get added in the proper order (i.e., last).  It also continues to have us use a single file for fewer requests.

NOTE: all Brackets CSS/LESS should still go in `bramble_overrides.less`