### PR TITLE
Fix #331 -Pressing ENTER after </html> causes TypeError: Cannot read property 'mark' of null #731

### DIFF
--- a/src/LiveDevelopment/MultiBrowserImpl/language/HTMLInstrumentation.js
+++ b/src/LiveDevelopment/MultiBrowserImpl/language/HTMLInstrumentation.js
@@ -151,7 +151,7 @@ define(function (require, exports, module) {
                     match = marks[marks.length - 2];
                 } else {
                     // We must be outside the root, so there's no containing tag.
-                    match = null;
+                    match.mark = null;
                 }
             }
         }


### PR DESCRIPTION
Hey, I got rid of the error when you press enter after the end of the tag.
My fix doesn't seem to have broken anything so hopefully its good.
I saw that the function returned match.mark, but the else set match to null, so I think that if match is null it cant have a match.mark.

After fix:
![e668389e-2512-11e7-8c17-117fb1db6de5](https://cloud.githubusercontent.com/assets/16922991/25257551/b4b3fed8-2606-11e7-852c-0cd98f38770e.gif)

Fixes #331