### PR TITLE
Fix: 1902 Add a way to hide the preview

### DIFF
--- a/src/bramble/client/main.js
+++ b/src/bramble/client/main.js
@@ -911,6 +911,14 @@ define([
         this._executeRemoteCommand({commandCategory: "bramble", command: "BRAMBLE_HIDE_SIDEBAR"}, callback);
     };
 
+    BrambleProxy.prototype.showPreview = function(callback) {
+        this._executeRemoteCommand({commandCategory: "bramble", command: "BRAMBLE_SHOW_PREVIEW"}, callback);
+    };
+
+    BrambleProxy.prototype.hidePreview = function(callback) {
+        this._executeRemoteCommand({commandCategory: "bramble", command: "BRAMBLE_HIDE_PREVIEW"}, callback);
+    };
+
     BrambleProxy.prototype.showStatusbar = function(callback) {
         this._executeRemoteCommand({commandCategory: "bramble", command: "BRAMBLE_SHOW_STATUSBAR"}, callback);
     };

--- a/src/extensions/default/bramble/lib/MouseManager.js
+++ b/src/extensions/default/bramble/lib/MouseManager.js
@@ -11,23 +11,23 @@ define(function (require, exports, module) {
     var FileSystem = brackets.getModule("filesystem/FileSystem");
 
     var MouseManagerRemote = require("text!lib/MouseManagerRemote.js");
-    var IframeBrowser = require("lib/iframe-browser");
+    var Preview = require("lib/Preview");
 
     var _isInspectorEnabled = false;
     var _prevLineMarker;
     var _prevElemHighlightId;
 
     // Override the preview document's cursor property
-    function setIframeCursor(value) {
-        var iframe;
+    function setPreviewCursor(value) {
+        var preview;
         var doc;
 
-        iframe = IframeBrowser.getBrowserIframe();
-        if(!iframe) {
+        preview = Preview.getPreviewPane();
+        if(!preview) {
             return;
         }
 
-        doc = iframe.contentDocument || iframe.contentWindow.document;
+        doc = preview.contentDocument || preview.contentWindow.document;
         if(!doc) {
             return;
         }
@@ -38,9 +38,9 @@ define(function (require, exports, module) {
     // Depending on the state of the inspector, apply the appropriate cursor
     function ensurePreviewCursor() {
         if(_isInspectorEnabled) {
-            setIframeCursor("pointer");
+            setPreviewCursor("pointer");
         } else {
-            setIframeCursor("auto");
+            setPreviewCursor("auto");
         }
     }
 
@@ -108,7 +108,7 @@ define(function (require, exports, module) {
         clearMarks();
         clearElemHighlight();
         // Set the preview mouse cursor to a pointer
-        setIframeCursor("pointer");
+        setPreviewCursor("pointer");
         // Let clients know we've enabled the inspector
         BrambleEvents.triggerInspectorChange(true);
     }
@@ -116,7 +116,7 @@ define(function (require, exports, module) {
     function disableInspector(clear) {
         _isInspectorEnabled = false;
         // reset the preview mouse cursor
-        setIframeCursor("auto");
+        setPreviewCursor("auto");
         // Depending on how this is called (user request vs. our logic)
         // clear any highlights in the preview/editor.
         if(clear) {

--- a/src/extensions/default/bramble/lib/PostMessageTransport.js
+++ b/src/extensions/default/bramble/lib/PostMessageTransport.js
@@ -6,11 +6,11 @@
 define(function (require, exports, module) {
     "use strict";
 
-    var _iframeRef,
+    var _previewRef,
         connId = 1;
 
     var Launcher = require("lib/launcher"),
-        Browser  = require("lib/iframe-browser");
+        Preview  = require("lib/Preview");
 
     var EventDispatcher     = brackets.getModule("utils/EventDispatcher"),
         LiveDevMultiBrowser = brackets.getModule("LiveDevelopment/LiveDevMultiBrowser"),
@@ -32,12 +32,12 @@ define(function (require, exports, module) {
     EventDispatcher.makeEventDispatcher(module.exports);
 
     /**
-     * Saves a reference of the iframe element to a local variable
-     * @param {DOM element reference to an iframe}
+     * Saves a reference of the preview element to a local variable
+     * @param {DOM element reference to a preview}
      */
-    function setIframe(iframeRef) {
-        if(iframeRef) {
-            _iframeRef = iframeRef;
+    function setPreviewPane(previewRef) {
+        if(previewRef) {
+            _previewRef = previewRef;
         }
     }
 
@@ -100,7 +100,7 @@ define(function (require, exports, module) {
             // Trigger message event
             module.exports.trigger("message", [connId, msgObj.message]);
         } else if (msgObj.type === "connect") {
-            Browser.setListener();
+            Preview.setListener();
             // Make sure the correct mouse cursor is set, depending on inspector state.
             MouseManager.ensurePreviewCursor();
         }
@@ -164,10 +164,10 @@ define(function (require, exports, module) {
      * @param {string} msgStr The message to send as a JSON string.
      */
     function send(idOrArray, msgStr){
-        var win = _iframeRef.contentWindow;
+        var win = _previewRef.contentWindow;
         msgStr = resolvePaths(msgStr);
         var msg = JSON.parse(msgStr);
-        var detachedPreview = Browser.getDetachedPreview();
+        var detachedPreview = Preview.getDetachedPreview();
 
         // Because we need to deal with reloads on this side (i.e., editor) of the
         // transport, check message before sending to remote, and reload if necessary
@@ -262,7 +262,7 @@ define(function (require, exports, module) {
     // Exports
     module.exports.getRemoteScript = getRemoteScript;
     module.exports.setAutoUpdate   = setAutoUpdate;
-    module.exports.setIframe       = setIframe;
+    module.exports.setPreviewPane  = setPreviewPane;
     module.exports.start           = start;
     module.exports.send            = send;
     module.exports.close           = close;

--- a/src/extensions/default/bramble/lib/RemoteCommandHandler.js
+++ b/src/extensions/default/bramble/lib/RemoteCommandHandler.js
@@ -22,6 +22,7 @@ define(function (require, exports, module) {
     var Tutorial = require("lib/Tutorial");
     var Theme = require("lib/Theme");
     var UI = require("lib/UI");
+    var Preview = require("lib/Preview");
 
     function _remoteCallbackFn(callback) {
         return function() {
@@ -140,6 +141,12 @@ define(function (require, exports, module) {
             break;
         case "BRAMBLE_HIDE_STATUSBAR":
             StatusBar.disable();
+            break;
+        case "BRAMBLE_SHOW_PREVIEW":
+            Preview.showPreview();
+            break;
+        case "BRAMBLE_HIDE_PREVIEW":
+            Preview.hidePreview();
             break;
         case "BRAMBLE_SHOW_STATUSBAR":
             StatusBar.enable();

--- a/src/extensions/default/bramble/lib/UI.js
+++ b/src/extensions/default/bramble/lib/UI.js
@@ -21,7 +21,7 @@ define(function (require, exports, module) {
 
     var PhonePreview  = require("text!lib/Mobile.html");
     var PostMessageTransport = require("lib/PostMessageTransport");
-    var IframeBrowser = require("lib/iframe-browser");
+    var Preview = require("lib/Preview");
     var Compatibility = require("lib/compatibility");
     var Theme = require("lib/Theme");
 
@@ -255,7 +255,7 @@ define(function (require, exports, module) {
         StatusBar.updateIndicator("mobileViewButtonBox", true, "",
                                   "Click to open preview in a mobile view");
 
-        $("#bramble-iframe-browser").appendTo("#second-pane");
+        $("#bramble-preview-pane").appendTo("#second-pane");
         $(".phone-wrapper").detach();
         $("#second-pane").removeClass("second-pane-scroll");
         $("#second-pane").off("click", stealFocus);
@@ -280,9 +280,9 @@ define(function (require, exports, module) {
         StatusBar.updateIndicator("mobileViewButtonBox", true, "",
                                   "Click to open preview in a desktop view");
 
-        $("#bramble-iframe-browser").addClass("phone-body");
+        $("#bramble-preview-pane").addClass("phone-body");
         $("#second-pane").append(PhonePreview);
-        $("#bramble-iframe-browser").appendTo("#phone-content");
+        $("#bramble-preview-pane").appendTo("#phone-content");
         $("#second-pane").addClass("second-pane-scroll");
 
         // Give focus back to the editor when the outside of the mobile phone is clicked.
@@ -337,23 +337,23 @@ define(function (require, exports, module) {
             // If it is, the attached preview is hidden
             // and the detached preview is opened.
             if(Resizer.isVisible("#second-pane")) {
-                IframeBrowser.detachPreview();
+                Preview.detachPreview();
             }
             else {
-                IframeBrowser.attachPreview();
+                Preview.attachPreview();
             }
         });
 
         Compatibility.supportsIFrameHTMLBlobURL(function(err, isCompatible) {
             if(err) {
-                console.error("[Brackets IFrame-Browser] Unexpected error:", err);
+                console.error("[Brackets Preview Pane] Unexpected error:", err);
                 return callback();
             }
 
             // If we are in IE v<11, we hide the detachable preview button
             if(!isCompatible && document.all) {
                 $("#liveDevButton").css("display", "none");
-                console.log("[Brackets IFrame-Browser] Detachable preview disabled due to incompatibility with current browser (you are possibly running IE 10 or below)");
+                console.log("[Brackets Preview Pane] Detachable preview disabled due to incompatibility with current browser (you are possibly running IE 10 or below)");
             }
 
             callback();

--- a/src/extensions/default/bramble/main.js
+++ b/src/extensions/default/bramble/main.js
@@ -19,7 +19,7 @@ define(function (require, exports, module) {
         CommandManager       = brackets.getModule("command/CommandManager"),
         Commands             = brackets.getModule("command/Commands"),
         FileSystem           = brackets.getModule("filesystem/FileSystem"),
-        Browser              = require("lib/iframe-browser"),
+        Preview              = require("lib/Preview"),
         UI                   = require("lib/UI"),
         Launcher             = require("lib/launcher"),
         NoHost               = require("nohost/main"),
@@ -46,7 +46,7 @@ define(function (require, exports, module) {
     }
 
     function handleMessage(message) {
-        var currentDocUrl = Browser.getBrowserIframe().src;
+        var currentDocUrl = Preview.getPreviewPane().src;
         var currentDocPath = BlobUtils.getFilename(currentDocUrl);
         var currentDir = currentDocPath !== currentDocUrl ? Path.dirname(currentDocPath) : currentDocPath;
         var requestedPath;
@@ -66,7 +66,7 @@ define(function (require, exports, module) {
 
     function startLiveDev() {
         // Turn preview iFrame On
-        Browser.init();
+        Preview.init();
 
         // Flip livedev.multibrowser to true
         var prefs = PreferencesManager.getExtensionPrefs("livedev");
@@ -76,12 +76,12 @@ define(function (require, exports, module) {
         NoHost.init();
 
         // Set up our transport and plug it into live-dev
-        PostMessageTransport.setIframe(Browser.getBrowserIframe());
+        PostMessageTransport.setPreviewPane(Preview.getPreviewPane());
         LiveDevelopment.setTransport(PostMessageTransport);
 
         // Set up our launcher in a similar manner
         LiveDevelopment.setLauncher(new Launcher({
-            browser: Browser,
+            browser: Preview,
             server: NoHost.getHTMLServer()
         }));
 
@@ -150,7 +150,7 @@ define(function (require, exports, module) {
                     // Signal that Brackets is loaded
                     AppInit._dispatchReady(AppInit.APP_READY);
 
-                    // Setup the iframe browser and Blob URL live dev servers and
+                    // Setup the Preview Pane and Blob URL live dev servers and
                     // load the initial document into the preview.
                     startLiveDev();
 


### PR DESCRIPTION
With this PR we can now toggle the preview window in the same way as the file tree
As pointed out [here](https://github.com/mozilla/brackets/pull/727#issuecomment-295319411) did refactor and changes to `iframe-browser.js` 
[Fix:1902](https://github.com/mozilla/thimble.mozilla.org/issues/1902)