### PR TITLE
Fixes #1790, Hover effect missing for Upload dialog and color consistency

### DIFF
--- a/src/styles/brackets_patterns_override.less
+++ b/src/styles/brackets_patterns_override.less
@@ -1490,6 +1490,7 @@ input[type="color"],
 // Base .btn styles
 
 .btn.disabled,
+.btn:hover,
 .btn[disabled] {
     background-color: @bc-btn-bg;
     color: @bc-text;
@@ -1500,19 +1501,17 @@ input[type="color"],
     }
 }
 
-.btn:hover,
-.btn:focus {
+.btn:hover:enabled,
+.btn:focus:enabled {
     background-color: #ffffff;
-    color: @bc-text;
 
     .dark & {
         background-color: #2b2b2b;
-        color: @dark-bc-text;
     }
 }
 
-.btn.primary:hover,
-.btn.primary:focus,
+.btn.primary:hover:enabled,
+.btn.primary:focus:enabled,
 .btn.primary.disabled,
 .btn.primary[disabled] {
     background-color: #39aa6d;
@@ -1546,27 +1545,23 @@ input[type="color"],
         box-shadow: inset 0 1px @dark-bc-highlight;
     }
 
-    &:hover {
+    &:hover:enabled {
         background-color: #ffffff;
-        color: @bc-text;
 
         .dark & {
             background-color: #2b2b2b;
-            color: @dark-bc-text;
         }
     }
 
     // Focus state for keyboard and accessibility
-    &:focus {
+    &:focus:enabled {
         border: 1px solid @bc-btn-border-focused;
         box-shadow: inset 0 1px 0 @bc-highlight, 0 0 0 1px @bc-btn-border-focused-glow;
-        color: @bc-text;
         outline: none;
 
         .dark & {
             border: 1px solid @dark-bc-btn-border-focused;
             box-shadow: inset 0 1px 0 @dark-bc-highlight, 0 0 0 1px @dark-bc-btn-border-focused-glow;
-            color: @dark-bc-text;
         }
     }
 

--- a/src/styles/brackets_patterns_override.less
+++ b/src/styles/brackets_patterns_override.less
@@ -1489,8 +1489,6 @@ input[type="color"],
 
 // Base .btn styles
 
-.btn:hover,
-.btn:focus,
 .btn.disabled,
 .btn[disabled] {
     background-color: @bc-btn-bg;
@@ -1502,14 +1500,25 @@ input[type="color"],
     }
 }
 
+.btn:hover,
+.btn:focus {
+    background-color: #ffffff;
+    color: @bc-text;
+
+    .dark & {
+        background-color: #2b2b2b;
+        color: @dark-bc-text;
+    }
+}
+
 .btn.primary:hover,
 .btn.primary:focus,
 .btn.primary.disabled,
 .btn.primary[disabled] {
-    background-color: @bc-primary-btn-bg;
+    background-color: #39aa6d;
 
     .dark & {
-        background-color: @dark-bc-primary-btn-bg;
+        background-color: #39aa6d;
     }
 }
 
@@ -1538,11 +1547,11 @@ input[type="color"],
     }
 
     &:hover {
-        background-color: @bc-btn-bg;
+        background-color: #ffffff;
         color: @bc-text;
 
         .dark & {
-            background-color: @dark-bc-btn-bg;
+            background-color: #2b2b2b;
             color: @dark-bc-text;
         }
     }
@@ -1607,14 +1616,14 @@ input[type="color"],
     // Primary Button Type
     &.primary {
         background-image: none;
-        background-color: @bc-primary-btn-bg;
+        background-color: #2a9961;
         border: 1px solid  @bc-primary-btn-border;
         box-shadow: inset 0 1px 0 @bc-highlight;
         color: @bc-text-alt;
         text-shadow: none;
 
         .dark & {
-            background-color: @dark-bc-primary-btn-bg;
+            background-color: #2a9961;
             border: 1px solid  @dark-bc-primary-btn-border;
             box-shadow: inset 0 1px 0 @dark-bc-highlight;
             color: @dark-bc-text-alt

--- a/src/styles/brackets_patterns_override.less
+++ b/src/styles/brackets_patterns_override.less
@@ -1490,7 +1490,6 @@ input[type="color"],
 // Base .btn styles
 
 .btn.disabled,
-.btn:hover,
 .btn[disabled] {
     background-color: @bc-btn-bg;
     color: @bc-text;


### PR DESCRIPTION
Fixes [#1790](https://github.com/mozilla/thimble.mozilla.org/issues/1790)

Added hover effects and made color consistent with the thimble theme color. (Based on Add file)
Hey @flukeout let me know any changes you may need.
 
Here is the final look light and dark:
![ezgif-3-9bbcb9a39c](https://cloud.githubusercontent.com/assets/11877279/25300010/75893af6-26d4-11e7-87d4-ab7620893b6e.gif)


Note:
I needed to add `:enabled` to hover effects, because it was still activating the `:hover` when the button was disabled. 
![ezgif-3-ff3874011a](https://cloud.githubusercontent.com/assets/11877279/25300015/84483268-26d4-11e7-94e9-69647d56d57d.gif)

Also had to remove `color: ` as it was changing the text color when the button was active:
<img width="311" alt="screen shot 2017-04-21 at 8 39 14 pm" src="https://cloud.githubusercontent.com/assets/11877279/25299993/1c5e02ea-26d4-11e7-9997-d40d4dee8a08.png">
