### PR TITLE
Fix #716 - Don't spam live dev console with Bracket's debug info

### DIFF
--- a/src/LiveDevelopment/MultiBrowserImpl/protocol/remote/LiveDevProtocolRemote.js
+++ b/src/LiveDevelopment/MultiBrowserImpl/protocol/remote/LiveDevProtocolRemote.js
@@ -62,7 +62,6 @@
             if (!msg.method) {
                 // no message type, ignoring it
                 // TODO: should we trigger a generic event?
-                //console.log("[Brackets LiveDev] Received message without method.");
                 return;
             }
             // get handlers for msg.method
@@ -76,15 +75,12 @@
                         handler(msg);
                         return;
                     } catch (e) {
-                        //console.log("[Brackets LiveDev] Error executing a handler for " + msg.method);
-                        //console.log(e.stack);
                         return;
                     }
                 });
             } else {
                 // no subscribers, ignore it.
                 // TODO: any other default handling? (eg. specific respond, trigger as a generic event, etc.);
-                //console.log("[Brackets LiveDev] No subscribers for message " + msg.method);
                 return;
             }
         },
@@ -96,8 +92,7 @@
          * @param {Object} response Message to be sent as the response.
          */
         respond: function (orig, response) {
-            if (!orig.id) {
-                //console.log("[Brackets LiveDev] Trying to send a response for a message with no ID");
+            if (!orig.id) { 
                 return;
             }
             response.id = orig.id;

--- a/src/LiveDevelopment/MultiBrowserImpl/protocol/remote/LiveDevProtocolRemote.js
+++ b/src/LiveDevelopment/MultiBrowserImpl/protocol/remote/LiveDevProtocolRemote.js
@@ -62,7 +62,7 @@
             if (!msg.method) {
                 // no message type, ignoring it
                 // TODO: should we trigger a generic event?
-                console.log("[Brackets LiveDev] Received message without method.");
+                //console.log("[Brackets LiveDev] Received message without method.");
                 return;
             }
             // get handlers for msg.method
@@ -76,15 +76,15 @@
                         handler(msg);
                         return;
                     } catch (e) {
-                        console.log("[Brackets LiveDev] Error executing a handler for " + msg.method);
-                        console.log(e.stack);
+                        //console.log("[Brackets LiveDev] Error executing a handler for " + msg.method);
+                        //console.log(e.stack);
                         return;
                     }
                 });
             } else {
                 // no subscribers, ignore it.
                 // TODO: any other default handling? (eg. specific respond, trigger as a generic event, etc.);
-                console.log("[Brackets LiveDev] No subscribers for message " + msg.method);
+                //console.log("[Brackets LiveDev] No subscribers for message " + msg.method);
                 return;
             }
         },
@@ -97,7 +97,7 @@
          */
         respond: function (orig, response) {
             if (!orig.id) {
-                console.log("[Brackets LiveDev] Trying to send a response for a message with no ID");
+                //console.log("[Brackets LiveDev] Trying to send a response for a message with no ID");
                 return;
             }
             response.id = orig.id;


### PR DESCRIPTION
I commented/silenced the LiveDev error messages.
It dose still create the violation errors but that is related to another issue.
After fix:
![aaa3](https://cloud.githubusercontent.com/assets/16922991/25301952/bff519d0-2700-11e7-87e7-2177ff85f893.gif)
Fixes #716