### PR TITLE
[WIP] Fix:1681 Removed the arrow in the fullscreen preview mode

### DIFF
--- a/src/styles/bramble_overrides.less
+++ b/src/styles/bramble_overrides.less
@@ -61,6 +61,14 @@
     left: 0 !important;
 }
 
+.fullscreen-preview .main-view .content #sidebar .horz-resizer {
+    visibility: hidden;
+}
+
+.fullscreen-preview .main-view #editor-holder .horz-resizer {
+    visibility: hidden;
+}
+
 .bramble-inspector-highlight {
     background: rgba(0, 135, 207, .3) !important;
 }


### PR DESCRIPTION
For this issue:  https://github.com/mozilla/thimble.mozilla.org/issues/1681

Removed the ability to see the arrow and resize the editor's borders in the fullscreen preview mode. 