### PR TITLE
Fixed excessive space before the line number & adjusted lineWidget position

### DIFF
--- a/src/styles/bramble_overrides.less
+++ b/src/styles/bramble_overrides.less
@@ -135,3 +135,7 @@ span.dialog-button {
 .horz-resizer:hover {
     opacity: 1;
 }
+
+.CodeMirror-linewidget {
+  transform: translateX(-10px);
+}

--- a/src/styles/bramble_overrides.less
+++ b/src/styles/bramble_overrides.less
@@ -96,7 +96,7 @@ span.dialog-button {
 }
 
 .CodeMirror-linenumber {
-    padding: 0 10px;
+    padding: 0 10px 0 0;
 }
 
 .inline-widget .CodeMirror-foldgutter,


### PR DESCRIPTION
If you inspect the gutter element that overlaps the numbers, it should be 31px wide now...

<img src="https://cloud.githubusercontent.com/assets/25212/25879063/211bee1e-34e4-11e7-9d7f-26c1360d1db7.png" width="250">

Additionally, the expandable inlineWidgets should align flush with the left edge of the page like this...

<img src="https://cloud.githubusercontent.com/assets/25212/25879208/2aac3b36-34e5-11e7-81fa-3a3547339f51.png" width="250">

There was a gap before.

cc @gideonthomas @humphd 

