### PR TITLE
Auto-indent snippets correctly when added

### DIFF
--- a/src/extensions/default/bramble/lib/BrambleCodeSnippets.js
+++ b/src/extensions/default/bramble/lib/BrambleCodeSnippets.js
@@ -3,17 +3,17 @@
 
 define(function (require, exports, module) {
     "use strict";
-	
+
     var CommandManager = brackets.getModule("command/CommandManager");
     var EditorManager  = brackets.getModule("editor/EditorManager");
     var MainViewManager = brackets.getModule("view/MainViewManager");
 
     var CMD_ADD_CODE_SNIPPET_ID     = "bramble.addCodeSnippet";
-	
+
     /* Example Snippet */
-    /*var snippet = 
+    /*var snippet =
     '<p> Hello World </p>'*/
-	
+
     function init() {
         /**
          * Inserts a code snippet into the editor.
@@ -24,13 +24,17 @@ define(function (require, exports, module) {
             var editor = EditorManager.getActiveEditor();
             if (editor) {
                 var insertionPos = editor.getCursorPos();
-                editor.document.replaceRange(snippet, insertionPos);
+                // We pass `paste` as the last parameter to `replaceRange` so
+                // as to trigger a codemirror change event from origin `paste`
+                // which in turn triggers the brackets-paste-and-indent
+                // extension to indent this code
+                editor.document.replaceRange(snippet, insertionPos, null, "paste");
             }
-        }	
-	
+        }
+
         CommandManager.registerInternal(CMD_ADD_CODE_SNIPPET_ID, addCodeSnippet);
     }
-	
+
     exports.init = init;
 });
 


### PR DESCRIPTION
Fix mozilla/thimble.mozilla.org#2045
\+ trailing whitespace removals from our code.