### PR TITLE
Don't use cached contents of SVG files, always read from disk. Fixes https://github.com/mozilla/thimble.mozilla.org/issues/2062

### DIFF
--- a/src/filesystem/File.js
+++ b/src/filesystem/File.js
@@ -27,6 +27,7 @@ define(function (require, exports, module) {
     var FileSystemEntry = require("filesystem/FileSystemEntry"),
         Content         = require("filesystem/impls/filer/lib/content"),
         Path            = require("filesystem/impls/filer/BracketsFiler").Path,
+        FilerUtils      = require("filesystem/impls/filer/FilerUtils"),
         defaultHTML     = require("text!filesystem/impls/filer/lib/default.html");
 
     /*
@@ -94,7 +95,11 @@ define(function (require, exports, module) {
         // for watched files. Note that we need to explicitly test this._contents
         // for a default value; otherwise it could be the empty string, which is
         // falsey.
-        if (this._contents !== null && this._stat) {
+        //
+        // XXXBramble: we don't ever want to use the cached contents of an SVG file,
+        // since we allow switching between UTF8 and Binary representations at runtime.
+        if (this._contents !== null && this._stat &&
+            FilerUtils.normalizeExtension(Path.extname(this._path)) !== ".svg") {
             callback(null, this._contents, this._stat);
             return;
         }


### PR DESCRIPTION
Brackets stashes a cached copy of a `File` object's `_contents` and `_stat` info when it reads it.  This is great in most cases, but fails when we switch between binary and UTF8 representations of an SVG at runtime: if we cache an SVG as binary, we'll have a `UTF8Array` vs. a `String` cached in `_contents` and it will fail when it tries to do string processing on it.

This PR fixes things so SVG files are always read from disk.  To test, you can drag an SVG into your file tree, then in your console, try doing:

```
bramble.openSVGasXML()
bramble.openSVGasImage()
``

Both should do what you expect.