### PR TITLE
Fix https://github.com/mozilla/thimble.mozilla.org/issues/2077 - always show console icon

### DIFF
--- a/src/extensions/default/bramble/stylesheets/consoleTheme.less
+++ b/src/extensions/default/bramble/stylesheets/consoleTheme.less
@@ -128,6 +128,7 @@
     opacity: .5;
     transition: all .2s ease-out;
     cursor: pointer;
+    z-index: 10;
 }
 
 .dark .show-console-tab {


### PR DESCRIPTION
If there's a better way to fix this, let me know, but this works well.