### PR TITLE
Fixes a styling bug on the mobile preview.

### DIFF
--- a/src/extensions/default/bramble/stylesheets/style.less
+++ b/src/extensions/default/bramble/stylesheets/style.less
@@ -99,7 +99,7 @@
     height: 30px;
     width: 30px;
     position: absolute;
-    left: calc(50% - 18px);
+    left: ~"calc(50% - 18px)";
     border-radius: 30px;
     bottom: 13px;
     border: 3px solid #444;


### PR DESCRIPTION
Button on the bottom of the phone preview should appear centered again...

![image](https://cloud.githubusercontent.com/assets/25212/26010778/192837d2-3703-11e7-86ec-3ee8bb268014.png)


Fixes https://github.com/mozilla/thimble.mozilla.org/issues/2081