### PR TITLE
Added helper text when the console is empty. Fixes https://github.com/mozilla/thimble.mozilla.org/issues/2091

### DIFF
--- a/locales/en-US/editor.properties
+++ b/locales/en-US/editor.properties
@@ -215,7 +215,7 @@ CONSOLE_TITLE=Console
 # Tooltip that shows when hovering over the console icon in the Thimble preview
 CONSOLE_TOOLTIP=Open the JavaScript Console
 # Text that shows up when the console is empty with instructions on how to use it
-CONSOLE_HELPTEXT=To use the console, add  <code>console.log("Hello World!");</code> to your JavasScript file.
+CONSOLE_HELPTEXT=To use the console, add <code>console.log("Hello World!");</code> to your JavasScript file.
 # The text show in the button to clear the console of all previous messages
 CONSOLE_CLEAR=Clear
 # Tooltip that shows when hovering over the Clear button, which clears previous logs in the console

--- a/locales/en-US/editor.properties
+++ b/locales/en-US/editor.properties
@@ -214,6 +214,8 @@ ERROR_MOVING_FILE_SAME_NAME=A file or folder with the name {0} already exists in
 CONSOLE_TITLE=Console
 # Tooltip that shows when hovering over the console icon in the Thimble preview
 CONSOLE_TOOLTIP=Open the JavaScript Console
+# Text that shows up when the console is empty with instructions on how to use it
+CONSOLE_HELPTEXT=To use the console, add  <code>console.log("Hello World!");</code> to your JavasScript file.
 # The text show in the button to clear the console of all previous messages
 CONSOLE_CLEAR=Clear
 # Tooltip that shows when hovering over the Clear button, which clears previous logs in the console

--- a/src/extensions/default/bramble/htmlContent/console.html
+++ b/src/extensions/default/bramble/htmlContent/console.html
@@ -4,5 +4,9 @@
         <button id="clearConsole" title="{{CONSOLE_CLEAR_TOOLTIP}}" class="clear-button">{{CONSOLE_CLEAR}}</button>
         <button title="{{CONSOLE_CLOSE_TOOLTIP}}"href="#" class="close"></button>
     </div>
-    <div class="console"></div>
+    <div class="console">
+      <div class="helper">
+        <span class="helper-text">{{&CONSOLE_HELPTEXT}}</span>
+      </div>
+    </div>
 </div>

--- a/src/extensions/default/bramble/lib/ConsoleInterfaceManager.js
+++ b/src/extensions/default/bramble/lib/ConsoleInterfaceManager.js
@@ -45,7 +45,7 @@ define(function (require, exports, module) {
         maxLogs = 30;
 
     function clear() {
-        consoleEl.html("");
+        consoleEl.find(".log-entry").remove();
         unreadCount = 0;
     }
 

--- a/src/extensions/default/bramble/stylesheets/consoleTheme.less
+++ b/src/extensions/default/bramble/stylesheets/consoleTheme.less
@@ -7,6 +7,7 @@
     max-height: inherit;
     height: ~"calc(100% - 44px)" !important;
     box-sizing: border-box;
+    position: relative;
 }
 
 #editor-console .log-entry {
@@ -24,6 +25,53 @@
     transform-origin: 15% 50%;
     white-space: pre-line;
 }
+
+#editor-console .console .helper {
+    font-size: 15px;
+    font-family: 'Menlo Regular', Consolas, Inconsolata, 'Vera Sans', 'Lucida Console', Courier, monospace, fixed;
+    display: none;
+    color: black;
+    position: absolute;
+    top: 0;
+    left: 0;
+    text-align: center;
+    vertical-align: center;
+    bottom: 0;
+    right: 0;
+    align-items: center;
+    justify-content: center;
+}
+
+.dark #editor-console .console .helper {
+    color: white;
+}
+
+#editor-console .console .helper span {
+    flex: 1;
+    color: rgba(0,0,0,.6);
+}
+
+.dark #editor-console .console .helper span {
+    color: rgba(255,255,255,.6);
+}
+
+#editor-console .console .helper code {
+    color: rgba(0,0,0,.8);
+    background: rgba(0,0,0,.1);
+    padding: 4px 5px;
+    font-weight: bold;
+    user-select: text;
+}
+
+.dark #editor-console .console .helper code {
+    color: rgba(255,255,255,1);
+    background: rgba(255,255,255,.1);
+}
+
+#editor-console .console .helper:only-child {
+    display: flex;
+}
+
 
 .dark #editor-console .log-entry {
     color: white;
@@ -259,22 +307,22 @@
 }
 
 .dark #editor-console .clear-button {
-  background: #222;
-  color: rgba(255,255,255,.5);
+    background: #222;
+    color: rgba(255,255,255,.5);
 }
 
 #editor-console .clear-button:hover {
-  color: rgba(0,0,0,.7);
+    color: rgba(0,0,0,.7);
 }
 
 .dark #editor-console .clear-button:hover {
-  color: rgba(255,255,255,.8);
+    color: rgba(255,255,255,.8);
 }
 
 #editor-console .clear-button:active {
-  background: rgba(255,255,255,1);
+    background: rgba(255,255,255,1);
 }
 
 .dark #editor-console .clear-button:active {
-  background: #1b1b1b;
+    background: #1b1b1b;
 }


### PR DESCRIPTION
When there are no log entries in the console, now we show a handy message so people can figure out how to use it.

Should appear like this when console is empty...

![image](https://cloud.githubusercontent.com/assets/25212/26017449/71c17a5a-371e-11e7-8874-bf0639c2a87c.png)

Fixes https://github.com/mozilla/thimble.mozilla.org/issues/2091