### PR TITLE
Remove LESS transform, since we no longer ship LESS in production.

### DIFF
--- a/src/filesystem/impls/filer/lib/transforms.js
+++ b/src/filesystem/impls/filer/lib/transforms.js
@@ -159,29 +159,9 @@ define(function (require, exports, module) {
         });
     }
 
-    function _setupLessTransform() {
-        function lessToCSS(path, less, callback) {
-            ExtensionUtils.parseLessCode(less, path)
-                .done(function(css) {
-                    callback(null, css);
-                })
-                .fail(function() {
-                    callback(new Error("[Bramble transform] unable to parse less file " + path));
-                });
-        }
-
-        _register(new Transform({
-            srcExt: "less",
-            destExt: "css",
-            startComment: "/**",
-            endComment: "**/"
-        }, lessToCSS));
-    }
-
     function init() {
         LanguageManager.ready.always(function() {
             _setupMarkdownTransform();
-            _setupLessTransform();
         });
     }
 


### PR DESCRIPTION
This fixes https://github.com/mozilla/thimble.mozilla.org/issues/2189.  I ripped LESS out of our production builds to save time+space, and forgot that the LESS transform also used it.  I think this was an interesting experiment, but not well done (we only supported a very limited set of what LESS could do, since we didn't allow imports).  This removes it.