### PR TITLE
Update bramble.addNewFolder() to work with new Brackets API

### DIFF
--- a/src/bramble/client/main.js
+++ b/src/bramble/client/main.js
@@ -1026,7 +1026,7 @@ define([
     };
 
     BrambleProxy.prototype.addNewFolder = function(callback) {
-        this._executeRemoteCommand({commandCategory: "brackets", command: "FILE_FOLDER"}, callback);
+        this._executeRemoteCommand({commandCategory: "brackets", command: "FILE_NEW_FOLDER"}, callback);
     };
 
     BrambleProxy.prototype.export = function(callback) {

--- a/src/extensions/default/bramble/lib/RemoteCommandHandler.js
+++ b/src/extensions/default/bramble/lib/RemoteCommandHandler.js
@@ -40,6 +40,11 @@ define(function (require, exports, module) {
             CommandManager.execute.apply(null, args).always(callback);
         }
 
+        // Fix outdated calls for new folder command (used to be FILE_FOLDER)
+        if(command === "FILE_FOLDER") {
+            command = "FILE_NEW_FOLDER";
+        }
+
         // Some commands require focus in the editor
         switch(command) {
         case "EDIT_UNDO":


### PR DESCRIPTION
Some corrections to the code that does `bramble.addNewFolder()`, which I want to call from Thimble as part of changes I'm making for https://github.com/mozilla/thimble.mozilla.org/issues/2072.

This fixes old style `FILE_FOLDER` commands so that existing Bramble code will work, as well as fixing it to do the right thing going forward (i.e., I don't just want to change it, since cached SW code will break).