### PR TITLE
Fix #751: fix logic around when to rewrite CSS files

### DIFF
--- a/src/extensions/default/bramble/nohost/HTMLServer.js
+++ b/src/extensions/default/bramble/nohost/HTMLServer.js
@@ -114,15 +114,6 @@ define(function (require, exports, module) {
         var liveDocument = this.get(path);
 
         function serveCSS(path, css, callback) {
-            // If we already have a cached Blob URL for this path, use it,
-            // otherwise generate a new one. This can happen if a file is included
-            // more than once in the same HTML file (e.g., multiple <link>s with same `src`).
-            var existingURL = BlobUtils.getUrl(path);
-            if(existingURL !== path) {
-                callback(null, existingURL);
-                return;
-            }
-
             CSSRewriter.rewrite(path, css, function(err, css) {
                 if(err) {
                     callback(err);
@@ -130,7 +121,6 @@ define(function (require, exports, module) {
                 }
                 callback(null, BlobUtils.createURL(path, css, "text/css"));
             });
-
         }
 
         function serveHTML(path, html, server, callback) {


### PR DESCRIPTION
This fixes the problem outlined here by @gideonthomas: https://github.com/mozilla/brackets/issues/751#issue-227511706.  I was being to aggressive in my CSS URL caching.  This does it only at the level of a single rewrite call vs. globally.

cc @flukeout 