### PR TITLE
Escape path before using in remote transport scripts

### DIFF
--- a/src/extensions/default/bramble/lib/PostMessageTransport.js
+++ b/src/extensions/default/bramble/lib/PostMessageTransport.js
@@ -17,7 +17,9 @@ define(function (require, exports, module) {
         BlobUtils           = brackets.getModule("filesystem/impls/filer/BlobUtils"),
         BrambleEvents       = brackets.getModule("bramble/BrambleEvents"),
         Path                = brackets.getModule("filesystem/impls/filer/BracketsFiler").Path,
-        BrambleStartupState = brackets.getModule("bramble/StartupState");
+        BrambleStartupState = brackets.getModule("bramble/StartupState"),
+        Mustache            = brackets.getModule("thirdparty/mustache/mustache"),
+        escapedPathTemplate = Mustache.compile("{{path}}");
 
     // The script that will be injected into the previewed HTML to handle the other side of the post message connection.
     var PostMessageTransportRemote = require("text!lib/PostMessageTransportRemote.js");
@@ -203,11 +205,12 @@ define(function (require, exports, module) {
     function getRemoteScript(path) {
         var currentDoc = LiveDevMultiBrowser._getCurrentLiveDoc();
         var currentPath = path || (currentDoc && currentDoc.doc.file.fullPath);
+        var escapedPath = escapedPathTemplate({path: currentPath});
 
         return '<base href="' + window.location.href + '">\n' +
             "<script>\n" + PostMessageTransportRemote + "</script>\n" +
             "<script>\n" + XHRShim + "</script>\n" +
-            MouseManager.getRemoteScript(currentPath) +
+            MouseManager.getRemoteScript(escapedPath) +
             LinkManager.getRemoteScript() +
             ConsoleManager.getRemoteScript();
     }


### PR DESCRIPTION
Building on what @cadecairos started in https://github.com/mozilla/brackets/pull/769, and fixing https://github.com/MozillaFoundation/mofo-devops-private/issues/66.  This uses Mustache to escape the path, which is based on the URL.

To test, you can alter `src/hosted.js` like this:

```diff
diff --git a/src/hosted.js b/src/hosted.js
index b0d54d675..2e174ea37 100644
--- a/src/hosted.js
+++ b/src/hosted.js
@@ -15,7 +15,7 @@
     var forceFiles = window.location.search.indexOf("forceFiles=1") > -1;

     // Default filesystem content
-    var projectRoot = "/7/projects/30";
+    var projectRoot = "/7/projects/3' + alert(document.domain) + '0";

     var index = "<html>\n"                                  +
                 "  <head>\n"                                +
```

Doing so, and logging the `currentPath` vs. `escapedPath` we get:

```
/7/projects/3' + alert(document.domain) + '0/tutorial.html 

vs.

&#x2F;7&#x2F;projects&#x2F;3&#39; + alert(document.domain) + &#39;0&#x2F;tutorial.html
```

And the alert no longer shows.