### PR TITLE
Closing fullscreen mode sets proper pane widths again.

### DIFF
--- a/src/bramble/BrambleEvents.js
+++ b/src/bramble/BrambleEvents.js
@@ -14,8 +14,6 @@ define(function (require, exports, module) {
         var secondPane = $("#second-pane");
         var sidebar = $("#sidebar");
 
-        console.log(eventName);
-
         exports.trigger(eventName, sidebar.is(":visible") ? sidebar.width() : 0,
                                    firstPane ? firstPane.width() : 0,
                                    secondPane ? secondPane.width() : 0);

--- a/src/bramble/BrambleEvents.js
+++ b/src/bramble/BrambleEvents.js
@@ -14,6 +14,8 @@ define(function (require, exports, module) {
         var secondPane = $("#second-pane");
         var sidebar = $("#sidebar");
 
+        console.log(eventName);
+
         exports.trigger(eventName, sidebar.is(":visible") ? sidebar.width() : 0,
                                    firstPane ? firstPane.width() : 0,
                                    secondPane ? secondPane.width() : 0);
@@ -39,7 +41,7 @@ define(function (require, exports, module) {
 
     // Triggers when the fullscreen is disabled so that we can send out the
     // proper pane widths to Thimble.
-    exports.triggerFullscreeDisabled = function(mode) {
+    exports.triggerFullscreeDisabled = function() {
         triggerUpdateLayoutEvent("End");
     };
 

--- a/src/bramble/BrambleEvents.js
+++ b/src/bramble/BrambleEvents.js
@@ -22,12 +22,12 @@ define(function (require, exports, module) {
     EventDispatcher.makeEventDispatcher(exports);
 
     // bramble:updateLayoutStart event when layout begins to change
-    exports.triggerUpdateLayoutStart = function() {       
+    exports.triggerUpdateLayoutStart = function() {
         triggerUpdateLayoutEvent("Start");
     };
 
     // bramble:updateLayoutEnd event when layout finishes changing
-    exports.triggerUpdateLayoutEnd = function() {        
+    exports.triggerUpdateLayoutEnd = function() {
         triggerUpdateLayoutEvent("End");
     };
 
@@ -35,6 +35,12 @@ define(function (require, exports, module) {
     // `mode` should be "desktop" or "mobile"
     exports.triggerPreviewModeChange = function(mode) {
         exports.trigger("bramble:previewModeChange", mode);
+    };
+
+    // Triggers when the fullscreen is disabled so that we can send out the
+    // proper pane widths to Thimble.
+    exports.triggerFullscreeDisabled = function(mode) {
+        triggerUpdateLayoutEvent("End");
     };
 
     // bramble:themeChange event when the theme is switched

--- a/src/extensions/default/bramble/lib/UI.js
+++ b/src/extensions/default/bramble/lib/UI.js
@@ -241,6 +241,7 @@ define(function (require, exports, module) {
     function disableFullscreenPreview() {
         $("#main-view").removeClass("fullscreen-preview");
         MainViewManager.setActivePaneId("first-pane");
+        BrambleEvents.triggerFullscreeDisabled();
     }
 
     function showDesktopView(preventReload) {


### PR DESCRIPTION
This pairs with https://github.com/mozilla/thimble.mozilla.org/pull/2227

The goal of this is to correctly set the panel widths after exiting fullscreen mode so that the bars above the panels in Thimble can size themselves properly.