### PR TITLE
Fix various issues with image filters, colour swatches, and SVGs

### DIFF
--- a/src/htmlContent/image-view.html
+++ b/src/htmlContent/image-view.html
@@ -36,20 +36,22 @@
               </div>
             </div>
 
-            <div class="image-filter-actions">
-              <button class="btn btn-image-filter-reset" disabled="disabled">{{Strings.IMAGE_RESET_FILTERS}}</button>
-              <button class="btn btn-image-filter-save" disabled="disabled">{{Strings.IMAGE_SAVE_WITH_FILTERS}}</button>
-            </div>
+            <div id="image-filters-section" class="hide">
+              <div class="image-filter-actions">
+                <button class="btn btn-image-filter-reset" disabled="disabled">{{Strings.IMAGE_RESET_FILTERS}}</button>
+                <button class="btn btn-image-filter-save" disabled="disabled">{{Strings.IMAGE_SAVE_WITH_FILTERS}}</button>
+              </div>
 
-            <h3>{{Strings.IMAGE_FILTERS_TITLE}}</h3>
-            <div class="image-filters">
-                <button class="btn btn-pinhole">{{Strings.IMAGE_FILTER_PINHOLE}}</button>
-                <button class="btn btn-sepia">{{Strings.IMAGE_FILTER_SEPIA}}</button>
-                <button class="btn btn-contrast">{{Strings.IMAGE_FILTER_CONTRAST}}</button>
-                <button class="btn btn-vintage">{{Strings.IMAGE_FILTER_VINTAGE}}</button>
-                <button class="btn btn-sunrise">{{Strings.IMAGE_FILTER_SUNRISE}}</button>
-                <button class="btn btn-emboss">{{Strings.IMAGE_FILTER_EMBOSS}}</button>
-                <button class="btn btn-glowing-sun">{{Strings.IMAGE_FILTER_GLOWING_SUN}}</button>
+              <h3>{{Strings.IMAGE_FILTERS_TITLE}}</h3>
+              <div class="image-filters">
+                  <button class="btn btn-pinhole">{{Strings.IMAGE_FILTER_PINHOLE}}</button>
+                  <button class="btn btn-sepia">{{Strings.IMAGE_FILTER_SEPIA}}</button>
+                  <button class="btn btn-contrast">{{Strings.IMAGE_FILTER_CONTRAST}}</button>
+                  <button class="btn btn-vintage">{{Strings.IMAGE_FILTER_VINTAGE}}</button>
+                  <button class="btn btn-sunrise">{{Strings.IMAGE_FILTER_SUNRISE}}</button>
+                  <button class="btn btn-emboss">{{Strings.IMAGE_FILTER_EMBOSS}}</button>
+                  <button class="btn btn-glowing-sun">{{Strings.IMAGE_FILTER_GLOWING_SUN}}</button>
+              </div>
             </div>
         </div>
     </div>


### PR DESCRIPTION
Fixes a few bugs on file, including:

* https://github.com/mozilla/thimble.mozilla.org/issues/2222
* https://github.com/mozilla/brackets/issues/757

I've made the colour palette extraction code work with image filters, and update when the file is changed.  I've dealt with SVGs not supporting filters.  I've fixed some timing code in how the filters load.

Fixes #757