### PR TITLE
Hide resize handles in fullscreen mode

### DIFF
--- a/src/styles/bramble_overrides.less
+++ b/src/styles/bramble_overrides.less
@@ -204,17 +204,13 @@
     }
 }
 
-
 .dark  #editor-holder .image-filters button:hover {
     background: rgba(255,255,255,.12);
 }
 
-
-
 .dark #editor-holder .active-filter {
     background: #036C9E;
 }
-
 
 .dark #editor-holder .pane-content .image-view h3 {
     border-bottom: solid 1px rgba(255,255,255,.15);
@@ -229,11 +225,7 @@
     left: 0 !important;
 }
 
-.fullscreen-preview .main-view .content #sidebar .horz-resizer {
-    visibility: hidden;
-}
-
-.fullscreen-preview .main-view #editor-holder .horz-resizer {
+.fullscreen-preview .horz-resizer {
     visibility: hidden;
 }
 


### PR DESCRIPTION
Continues on the work started in @MargarytaChepiga

This stops you from being able to resize the editor panes (filetree, editor & preview) when the project is in fullscreen mode.

To test, view a project in Fullscreen mode, then move your mouse horizontally, slowly, across the length of the page. At no point should the cursor change into the resizing handle and allow you to resize the editor panes that is underneath the preview.

Fixes mozilla/thimble.mozilla.org#1681