### PR TITLE
Modal styling updates & modal events

### DIFF
--- a/README.md
+++ b/README.md
@@ -367,6 +367,8 @@ the following events:
 * `"autoUpdateChange"` - triggered whenever the auto update preference changes from enabled to disabled, or vice versa. It includes an `Object` with a `autoUpdate` property set to `true` or `false`
 * `"projectDirty"` - triggered when one of the files in the project has been edited and those changes haven't been saved yet. It includes an `Object` with the `path` to the current file.
 * `"projectSaved"` - triggered whenever the changes are saved to the filesystem in the browser are completed.
+* `"dialogOpened"` - triggered whenever a modal dialog opens, like when a user is deleting a file.
+* `"dialogClosed"` - triggered whenever a modal dialog closes.
 
 There are also high-level events for changes to files:
 

--- a/src/bramble/BrambleEvents.js
+++ b/src/bramble/BrambleEvents.js
@@ -26,6 +26,16 @@ define(function (require, exports, module) {
         triggerUpdateLayoutEvent("Start");
     };
 
+    // bramble:dialogOpened event when a modal dialog opens
+    exports.triggerDialogOpened = function() {
+      exports.trigger("bramble:dialogOpened");
+    };
+
+    // bramble:dialogOpened event when a modal dialog closes
+    exports.triggerDialogClosed = function() {
+      exports.trigger("bramble:dialogClosed");
+    };
+
     // bramble:updateLayoutEnd event when layout finishes changing
     exports.triggerUpdateLayoutEnd = function() {
         triggerUpdateLayoutEvent("End");

--- a/src/extensions/default/bramble/lib/RemoteEvents.js
+++ b/src/extensions/default/bramble/lib/RemoteEvents.js
@@ -65,6 +65,20 @@ define(function (require, exports, module) {
             });
         });
 
+        // Listen for changes to the sidebar
+        BrambleEvents.on("bramble:dialogOpened", function(e) {
+            sendEvent({
+                type: "bramble:dialogOpened"
+            });
+        });
+
+        // Listen for changes to the sidebar
+        BrambleEvents.on("bramble:dialogClosed", function(e) {
+            sendEvent({
+                type: "bramble:dialogClosed"
+            });
+        });
+
         // Listen for user changing file content
         BrambleEvents.on("bramble:projectDirty", function(e, path) {
             sendEvent({
@@ -72,7 +86,7 @@ define(function (require, exports, module) {
                 path: path
             });
         });
-        
+
         // Listen for files being saved for the whole project
         BrambleEvents.on("bramble:projectSaved", function(e) {
             sendEvent({

--- a/src/styles/bramble_overrides.less
+++ b/src/styles/bramble_overrides.less
@@ -308,15 +308,64 @@ span.dialog-button {
   transform: translateX(-10px);
 }
 
+.modal-backdrop {
+  opacity: .8;
+  animation: showModalBackdrop .1s ease-out;
+
+  @keyframes showModalBackdrop {
+    0% {
+      opacity: 0;
+    }
+    100% {
+      opacity: .8;
+    }
+  }
+}
 
 .dark .modal, .modal {
   background: white;
   border: none;
   border-radius: 0;
+  animation: showModal .25s ease-out;
+  transform: translateY(-100px);
+
+  @keyframes showModal {
+    0% {
+      transform: scale(.8);
+      transform: translateY(-80px);
+      opacity: 0;
+    }
+    60% {
+      transform: scale(1.04);
+      transform: translateY(-105px);
+    }
+    100% {
+      transform: scale(1);
+      transform: translateY(-100px);
+    }
+  }
 
   .modal-body {
     background: transparent;
     color: black;
+    border: none;
+    padding: 20px;
+  }
+
+  .dialog-title {
+    color: black;
+    font-family: "Open Sans", sans-serif;
+    padding: 20px 20px 0 20px;
+    font-weight: 600;
+
+    &:empty {
+      padding: 0;
+    }
+  }
+
+  .modal-header {
+    padding: 0;
+    background: transparent;
     border: none;
   }
 
@@ -324,31 +373,69 @@ span.dialog-button {
     font-family: "Open Sans";
     color: black;
     font-size: 16px;
+    margin: 0;
   }
 
   .modal-footer {
     background: rgba(0,0,0,.1);
     border-radius: 0;
     border: none;
+    padding: 15px 20px;
   }
 
   button {
-    float: right;
     margin-left: 10px;
     display: inline-block;
     padding: 8px 15px;
     cursor: pointer;
     color: white;
+    margin: 0;
+    border: none;
     -webkit-user-select: none;
     -moz-user-select: none;
     -ms-user-select: none;
-    border-bottom: solid 2px rgba(0,0,0,0.3);
     border-radius: 2px;
     background-color: #2A9961;
+    font-size: 16px;
+    font-weight: 600;
+    font-family: "Open Sans", sans-serif;
   }
-}
 
-.dark .modal-header {
-  background: transparent;
-  border: none;
+  .btn.primary {
+    border: none;
+    background-color: #2A9961;
+    border-bottom: solid 2px rgba(0,0,0,0.3);
+
+    &:hover {
+      background: #39AA6D;
+    }
+
+    &:active {
+      background: #288952;
+    }
+  }
+
+  .btn {
+    border: none;
+    background: #B0B0B0;
+    border-bottom: solid 2px rgba(0,0,0,0.3);
+
+    &:focus {
+      color: white;
+    }
+
+    &:hover {
+      background-color: #BCBCBC;
+      color: white;
+    }
+
+    &:active {
+      background-color: #9B9B9B;
+      position: relative;
+      color: white;
+      border-bottom: solid 2px transparent;
+      margin-top: 2px;
+      padding: 8px 15px 6px 15px;
+    }
+  }
 }

--- a/src/styles/bramble_overrides.less
+++ b/src/styles/bramble_overrides.less
@@ -307,3 +307,48 @@ span.dialog-button {
 .CodeMirror-linewidget {
   transform: translateX(-10px);
 }
+
+
+.dark .modal, .modal {
+  background: white;
+  border: none;
+  border-radius: 0;
+
+  .modal-body {
+    background: transparent;
+    color: black;
+    border: none;
+  }
+
+  .dialog-message {
+    font-family: "Open Sans";
+    color: black;
+    font-size: 16px;
+  }
+
+  .modal-footer {
+    background: rgba(0,0,0,.1);
+    border-radius: 0;
+    border: none;
+  }
+
+  button {
+    float: right;
+    margin-left: 10px;
+    display: inline-block;
+    padding: 8px 15px;
+    cursor: pointer;
+    color: white;
+    -webkit-user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
+    border-bottom: solid 2px rgba(0,0,0,0.3);
+    border-radius: 2px;
+    background-color: #2A9961;
+  }
+}
+
+.dark .modal-header {
+  background: transparent;
+  border: none;
+}

--- a/src/styles/bramble_overrides.less
+++ b/src/styles/bramble_overrides.less
@@ -322,26 +322,30 @@ span.dialog-button {
   }
 }
 
+
+// Modal overrides
+
+.modal-inner-wrapper {
+  vertical-align: top;
+}
+
 .dark .modal, .modal {
   background: white;
   border: none;
   border-radius: 0;
   animation: showModal .25s ease-out;
-  transform: translateY(-100px);
+  transform: translateY(70px);
 
   @keyframes showModal {
     0% {
-      transform: scale(.8);
-      transform: translateY(-80px);
+      transform: scale(.9) translateY(85px);
       opacity: 0;
     }
     60% {
-      transform: scale(1.04);
-      transform: translateY(-105px);
+      transform: scale(1.03) translateY(65px);
     }
     100% {
-      transform: scale(1);
-      transform: translateY(-100px);
+      transform: scale(1) translateY(70px);
     }
   }
 

--- a/src/widgets/Dialogs.js
+++ b/src/widgets/Dialogs.js
@@ -287,8 +287,6 @@ define(function (require, exports, module) {
      * @return {Dialog}
      */
     function showModalDialogUsingTemplate(template, autoDismiss) {
-        BrambleEvents.triggerDialogOpened();
-
         if (autoDismiss === undefined) {
             autoDismiss = true;
         }
@@ -316,8 +314,6 @@ define(function (require, exports, module) {
 
         // Pipe dialog-closing notification back to client code
         $dlg.one("hidden", function () {
-            BrambleEvents.triggerDialogClosed();
-
             var buttonId = $dlg.data("buttonId");
             if (!buttonId) {    // buttonId will be undefined if closed via Bootstrap's "x" button
                 buttonId = DIALOG_BTN_CANCEL;
@@ -328,6 +324,7 @@ define(function (require, exports, module) {
             // fade-out animation)
             window.setTimeout(function () {
                 result.resolve(buttonId);
+                BrambleEvents.triggerDialogClosed();
             }, 0);
 
             // Remove the dialog instance from the DOM.
@@ -359,6 +356,7 @@ define(function (require, exports, module) {
 
             // Push our global keydown handler onto the global stack of handlers.
             KeyBindingManager.addGlobalKeydownHook(keydownHook);
+            BrambleEvents.triggerDialogOpened();
         });
 
         // Click handler for buttons

--- a/src/widgets/Dialogs.js
+++ b/src/widgets/Dialogs.js
@@ -33,7 +33,9 @@ define(function (require, exports, module) {
         KeyEvent          = require("utils/KeyEvent"),
         Strings           = require("strings"),
         DialogTemplate    = require("text!htmlContent/dialog-template.html"),
-        Mustache          = require("thirdparty/mustache/mustache");
+        Mustache          = require("thirdparty/mustache/mustache"),
+        BrambleEvents     = brackets.getModule("bramble/BrambleEvents");
+
 
     /**
      * Dialog Buttons IDs
@@ -285,6 +287,8 @@ define(function (require, exports, module) {
      * @return {Dialog}
      */
     function showModalDialogUsingTemplate(template, autoDismiss) {
+        BrambleEvents.triggerDialogOpened();
+
         if (autoDismiss === undefined) {
             autoDismiss = true;
         }
@@ -312,6 +316,8 @@ define(function (require, exports, module) {
 
         // Pipe dialog-closing notification back to client code
         $dlg.one("hidden", function () {
+            BrambleEvents.triggerDialogClosed();
+
             var buttonId = $dlg.data("buttonId");
             if (!buttonId) {    // buttonId will be undefined if closed via Bootstrap's "x" button
                 buttonId = DIALOG_BTN_CANCEL;
@@ -332,7 +338,7 @@ define(function (require, exports, module) {
 
             // Restore previous focus
             if (lastFocus) {
-                lastFocus.focus();    
+                lastFocus.focus();
             }
 
             //Remove wrapper


### PR DESCRIPTION
Changes made...
* Modal styling is consistent with the rest of Thimble UI
* Styling is same independent of the Theme
* Brackets now sends out an event when a modal is opened or closed

Modals should looks like this for both themes...

![image](https://cloud.githubusercontent.com/assets/25212/26608348/02420e2a-4550-11e7-912f-e70abe31857b.png)

Modals tested so far:
* [x] Delete file 
* [x] Error when renaming file to a name that already exists
* [x] Selfie dialog
* [x] Upload dialog
* ... others?

Fixes https://github.com/mozilla/thimble.mozilla.org/issues/2202

This PR adds the events that https://github.com/mozilla/thimble.mozilla.org/pull/2230 needs.