### PR TITLE
Fix #700 Removed warning for deprecation, and removed brackets-paste-and-indent as a submodule

### DIFF
--- a/src/extensions/default/brackets-paste-and-indent/README.md
+++ b/src/extensions/default/brackets-paste-and-indent/README.md
@@ -1,0 +1,66 @@
+Paste and Indent
+==========
+
+**Extension for [Adobe Brackets](http://brackets.io)**
+
+Automatically apply the correct indentation to pasted text.
+
+When copying and pasting code, its indentation often ends up being wrong for
+where it was pasted. The resulting code ends up looking weird:
+
+```javascript
+if (Brackets === Awesome) {
+    if (Life === Good) {
+    return true;
+}
+}
+```
+
+This extension re-indents pasted code to be at the correct indentation level:
+
+```javascript
+if (Brackets === Awesome) {
+    if (Life === Good) {
+        return true;
+    }
+}
+```
+
+##Disabling
+
+Disable the extension for a specific project by adding the `"brackets-paste-and-indent.enabled": false`
+key/value to a `.brackets.json` JSON file at the root of your project. Changing this may require
+you to restart Brackets.
+
+##Install
+
+1. Open the Extension Manager
+2. Search for "paste and indent"
+3. Click "install"
+
+##License
+
+This is free and unencumbered software released into the public domain.
+
+Anyone is free to copy, modify, publish, use, compile, sell, or
+distribute this software, either in source code form or as a compiled
+binary, for any purpose, commercial or non-commercial, and by any
+means.
+
+In jurisdictions that recognize copyright laws, the author or authors
+of this software dedicate any and all copyright interest in the
+software to the public domain. We make this dedication for the benefit
+of the public at large and to the detriment of our heirs and
+successors. We intend this dedication to be an overt act of
+relinquishment in perpetuity of all present and future rights to this
+software under copyright law.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+
+For more information, please refer to <http://unlicense.org/>

--- a/src/extensions/default/brackets-paste-and-indent/main.js
+++ b/src/extensions/default/brackets-paste-and-indent/main.js
@@ -1,0 +1,50 @@
+/*jslint vars: true, plusplus: true, devel: true, nomen: true, regexp: true, indent: 4, maxerr: 50 */
+/*global define, $, brackets */
+
+// When code is pasted in the editor, re-indent the changed lines.
+define(function (require, exports, module) {
+    "use strict";
+
+    var MainViewManager = brackets.getModule("view/MainViewManager"),
+        EditorManager = brackets.getModule("editor/EditorManager"),
+        PreferencesManager = brackets.getModule("preferences/PreferencesManager"),
+        prefs = PreferencesManager.getExtensionPrefs("brackets-paste-and-indent");
+
+    // Define the `enabled` preference, default is `true`.
+    prefs.definePreference("enabled", "boolean", "true");
+
+    // Re-indent the editor in between specific lines. These are batched into
+    // one update.
+    function reindentLines(codeMirror, lineFrom, lineTo) {
+        codeMirror.operation(function () {
+            codeMirror.eachLine(lineFrom, lineTo, function (lineHandle) {
+                codeMirror.indentLine(lineHandle.lineNo(), "smart");
+            });
+        });
+    }
+
+    // When the Brackets document changes, attach an event listener for paste
+    // events on its internal codeMirror object.
+    MainViewManager.on("currentFileChange", function () {
+        var editor = EditorManager.getCurrentFullEditor();
+
+        if (!editor) {
+            return;
+        }
+
+        var codeMirror = editor._codeMirror;
+
+        // Listen for change events. If this change is not a 'paste', or the
+        // extension is disabled, return early.
+        codeMirror.on("change", function (codeMirror, change) {
+            if (!prefs.get("enabled") || change.origin !== "paste") {
+                return;
+            }
+
+            var lineFrom = change.from.line,
+                lineTo = change.from.line + change.text.length;
+
+            reindentLines(codeMirror, lineFrom, lineTo);
+        });
+    });
+});

--- a/src/extensions/default/brackets-paste-and-indent/package.json
+++ b/src/extensions/default/brackets-paste-and-indent/package.json
@@ -1,0 +1,18 @@
+{
+    "name": "brackets-paste-and-indent",
+    "title": "Paste and Indent",
+    "description": "Automatically apply the correct indentation to pasted text",
+    "homepage": "https://github.com/ahuth/brackets-paste-and-indent",
+    "version": "0.2.0",
+    "author": "Andrew Huth (https://github.com/ahuth)",
+    "license": "Unlicense",
+    "categories": "formatting",
+    "keywords": [
+        "format",
+        "paste",
+        "indent"
+    ],
+    "engines": {
+        "brackets": ">=0.36.0"
+    }
+}


### PR DESCRIPTION
Finishing work by @cgsingh started in https://github.com/mozilla/brackets/pull/708.

NOTE: this is going to necessitate some some dev environment changes, since I'm removing a submodule and adding the code back manually.  If you need help sorting it out, let me know.  cc @Pomax, @flukeout, @gideonthomas. 