### PR TITLE
Fix #723, Always run unlocalize script, always build iframe API

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -42,7 +42,8 @@ module.exports = function (grunt) {
             'grunt-targethtml',
             'grunt-usemin',
             'grunt-cleanempty',
-            'grunt-exec'
+            'grunt-exec',
+            'grunt-newer'
         ]
     });
 
@@ -217,7 +218,16 @@ module.exports = function (grunt) {
                 }
             },
             iframe: {
-                // Standalone dist/bramble.js iframe api
+                // Define files involved, so grunt-newer knows whether to re-build or not
+                files: {
+                    'dist/bramble.js': [
+                        'src/bramble/client/**/*.js',
+                        'src/bramble/thirdparty/**/*.js',
+                        'src/bramble/ChannelUtils.js',
+                        'thirdparty/filer/dist/filer.min.js',
+                    ]
+                },
+                // Standalone, minified dist/bramble.js iframe api
                 options: {
                     name: 'thirdparty/almond',
                     baseUrl: 'src',
@@ -538,6 +548,11 @@ module.exports = function (grunt) {
         'usemin'
         /* XXXBramble: we skip this, since we don't bother with its info, and copy it in copy:dist
         'build-config' */
+    ]);
+
+    // task: build for development, skipping most steps: only build iframe API if needed.
+    grunt.registerTask('build-browser-dev', [
+        'newer:requirejs:iframe'
     ]);
 
     // task: build dist/ for browser

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ The easiest way to run Bramble is to simply use:
 $ npm start
 ```
 
-This will generate the strings needed for localization in your `src/nls` folder and allow you to access Bramble on `localhost:8000`. You can terminate the server with `Ctrl+C` which will also clean up the strings that were generated in your `src/nls` folder.
+This will generate the strings needed for localization in your `src/nls` folder and allow you to access Bramble on `localhost:8000` (NOTE: you need npm version 5 for the cleanup step to run properly; if it doesn't, use `npm run unlocalize` to restore the files in `src/nls/**/*`). It will also build the Bramble iframe API in dist/ if necessary. You can terminate the server with `Ctrl+C` which will also clean up the strings that were generated in your `src/nls` folder.
 
 If you want to simply run the server without the localized strings, run:
 

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
         "test": "grunt test && grunt build-browser-compressed",
         "server": "http-server -p 8000 --cors",
         "prestart": "npm run localize && grunt build-browser-dev",
-        "start": "npm run server",
+        "start": "npm run server || true",
         "poststart": "npm run unlocalize"
     },
     "license": "MIT"

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     },
     "devDependencies": {
         "bluebird": "^3.4.7",
+        "grunt-newer": "^1.3.0",
         "gunzip-maybe": "^1.3.1",
         "http-server": "mozilla/http-server#gzip",
         "mkdirp": "0.5.1",
@@ -70,8 +71,9 @@
         "production": "npm start -- --gzip",
         "test": "grunt test && grunt build-browser-compressed",
         "server": "http-server -p 8000 --cors",
-        "prestart": "npm run localize",
-        "start": "npm run server && npm run unlocalize"
+        "prestart": "npm run localize && grunt build-browser-dev",
+        "start": "npm run server",
+        "poststart": "npm run unlocalize"
     },
     "license": "MIT"
 }

--- a/package.json
+++ b/package.json
@@ -71,8 +71,7 @@
         "test": "grunt test && grunt build-browser-compressed",
         "server": "http-server -p 8000 --cors",
         "prestart": "npm run localize",
-        "start": "npm run server",
-        "poststart": "npm run unlocalize"
+        "start": "npm run server && npm run unlocalize"
     },
     "license": "MIT"
 }

--- a/src/bramble/client/main.js
+++ b/src/bramble/client/main.js
@@ -24,7 +24,8 @@
 /*global define, HTMLElement, MessageChannel, addEventListener*/
 
 define([
-    // Change this to filer vs. filer.min if you need to debug Filer
+    // NOTE: if you modify the files involved here, also change the requirejs:iframe files list in Gruntfile.js
+    // filer.min - change this to filer vs. filer.min if you need to debug Filer
     "thirdparty/filer/dist/filer.min",
     "bramble/ChannelUtils",
     "bramble/thirdparty/EventEmitter/EventEmitter.min",

--- a/src/hosted.js
+++ b/src/hosted.js
@@ -130,13 +130,19 @@
         });
     }
 
-    // Support loading from src/ or dist/ to make local dev easier
-    require(["bramble/client/main"], function(Bramble) {
+    // Support loading from src/ or dist/ (default) to make local dev easier
+    var isSrc = !!window.location.pathname.match(/\/src\/[^/]+$/);
+    var brambleModule;
+
+    if(isSrc) {
+        console.log("Bramble src/ build");
+        brambleModule = "../dist/bramble";
+    } else {
+        console.log("Bramble dist/ build");
+        brambleModule = "bramble";
+    }
+
+    require([brambleModule], function(Bramble) {
         load(Bramble);
-    }, function(err) {
-        console.log("Unable to load Bramble from src/, trying from dist/");
-        require(["bramble"], function(Bramble) {
-            load(Bramble);
-        });
     });
 }());


### PR DESCRIPTION
Fixes #723 
@gideonthomas I'm sick of the `unlocalize` step not running when the dev server stops.  Despite what `npm` *should* do, the `post` script for `start` doesn't run in all versions of `npm`.  This fixes it so we always do it.