### PR TITLE
<Thimble> Fix #2232: Use a darker color for right-clicked selected file indicator

### DIFF
--- a/src/extensions/default/bramble/stylesheets/sidebarTheme.less
+++ b/src/extensions/default/bramble/stylesheets/sidebarTheme.less
@@ -185,6 +185,11 @@ li.jstree-leaf a.context-node {
     background: rgba(255,255,255,.08);
 }
 
+[data-theme='light-theme'] li.jstree-closed a.context-node,
+[data-theme='light-theme'] li.jstree-open a.context-node,
+[data-theme='light-theme'] li.jstree-leaf a.context-node {
+    background: rgba(0,0,0,.08);
+}
 
 /* Currently selected (edited) file */
 


### PR DESCRIPTION
mozilla/thimble.mozilla.org#2232

@flukeout @humphd 

