### PR TITLE
Fix https://github.com/mozilla/thimble.mozilla.org/issues/2266 - s/dist/src/

### DIFF
--- a/src/extensions/bramble-extensions.json
+++ b/src/extensions/bramble-extensions.json
@@ -55,7 +55,7 @@
         "path": "extensions/default/Inline3DParametersEditor",
         "less": {
             "dist/extensions/default/Inline3DParametersEditor/css/main.css": [
-                "dist/extensions/default/Inline3DParametersEditor/css/main.less"
+                "src/extensions/default/Inline3DParametersEditor/css/main.less"
             ]
         }
     },


### PR DESCRIPTION
We missed that the file comes from `src/` vs. `dist/` so it couldn't find it.  cc @hkirat 