### PR TITLE
Fix https://github.com/mozilla/thimble.mozilla.org/issues/2267 - copy bitjs-untar to dist

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -91,6 +91,7 @@ module.exports = function (grunt) {
                         src: [
                             'nls/{,*/}*.js',
                             'thirdparty/github-markdown.css',
+                            'thirdparty/bitjs/bitjs-untar.min.js',
                             'hosted.*',
                             // XXXBramble: we don't use src/config.json like Brackets does,
                             // but it needs to exist in dist/ so copy it


### PR DESCRIPTION
I forgot to copy this file over to `dist/`, which is why it was 404ing.