### PR TITLE
Fix #514, https://github.com/mozilla/thimble.mozilla.org/issues/1927 - show images in folders

### DIFF
--- a/src/extensions/default/BrambleUrlCodeHints/main.js
+++ b/src/extensions/default/BrambleUrlCodeHints/main.js
@@ -156,34 +156,34 @@ define(function (require, exports, module) {
                     }
 
                     function getFilesRecursively(targetDir, callback) {
-                    var directory = FileSystem.getDirectoryForPath(targetDir);
-                    var unfiltered = [];
-                    
-                    directory.getContents(function (err, contents) {
-                        var currentDeferred, entryStr, syncResults;
-                        if(err) {
-                            callback(err);
-                        }
-                        contents.forEach(function (entry) {
-                            if (!ProjectManager.shouldShow(entry)) {
-                            callback();
-                            }
-                            if (entry._isDirectory) {
-                            var fPath = entry._path;
-                            getFilesRecursively(fPath, function (err, files) {
-                                if (err) {
+                        var directory = FileSystem.getDirectoryForPath(targetDir);
+                        var unfiltered = [];
+                        directory.getContents(function (err, contents) {
+                            var currentDeferred, entryStr, syncResults;
+                            if(err) {
                                 callback(err);
-                                return;
-                                }
-                                unfiltered.push(files);
-                            });
-                            } else {
-                            entryStr = entry._name;
-                            unfiltered.push(entryStr);
                             }
+                            contents.forEach(function (entry) {
+                                if (!ProjectManager.shouldShow(entry)) {
+                                    callback();
+                                }
+                                if (entry._isDirectory) {
+                                    var fPath = entry._path;
+                                    getFilesRecursively(fPath, function (err, files) {
+                                        if (err) {
+                                            callback(err);
+                                            return;
+                                        }
+                                        unfiltered.push(files);
+                                    });
+                                } 
+                                else {
+                                    entryStr = entry._name;
+                                    unfiltered.push(entryStr);
+                                }
+                            });
                         });
-                    });
-                    callback(null, unfiltered);
+                        callback(null, unfiltered);
                     }
                     // convert to doc relative path
                     entryStr = queryDir + entry._name;

--- a/src/extensions/default/BrambleUrlCodeHints/main.js
+++ b/src/extensions/default/BrambleUrlCodeHints/main.js
@@ -155,13 +155,48 @@ define(function (require, exports, module) {
                         return;
                     }
 
+                    function getFilesRecursively(targetDir, callback) {
+                    var directory = FileSystem.getDirectoryForPath(targetDir);
+                    var unfiltered = [];
+                    
+                    directory.getContents(function (err, contents) {
+                        var currentDeferred, entryStr, syncResults;
+                        if(err) {
+                            callback(err);
+                        }
+                        contents.forEach(function (entry) {
+                            if (!ProjectManager.shouldShow(entry)) {
+                            callback();
+                            }
+                            if (entry._isDirectory) {
+                            var fPath = entry._path;
+                            getFilesRecursively(fPath, function (err, files) {
+                                if (err) {
+                                callback(err);
+                                return;
+                                }
+                                unfiltered.push(files);
+                            });
+                            } else {
+                            entryStr = entry._name;
+                            unfiltered.push(entryStr);
+                            }
+                        });
+                    });
+                    callback(null, unfiltered);
+                    }
                     // convert to doc relative path
                     entryStr = queryDir + entry._name;
-                    // TODO: should do a recursive walk of the files
+                    // walk of the files recursively
                     if (entry._isDirectory) {
-                        return;
+                        var fPath = entry._path;
+                        getFilesRecursively(fPath, function(err, data) {
+                            if (err) {
+                                return;
+                            }
+                            unfiltered.push(data);
+                        });
                     }
-
                     // code hints show the unencoded string so the
                     // choices are easier to read.  The encoded string
                     // will still be inserted into the editor.
@@ -213,7 +248,13 @@ define(function (require, exports, module) {
         unfiltered.forEach(function (item) {
             if(isImage) {
                 if(Content.isImage(Path.extname(item))) {
+                    if(Array.isArray(item)){
+                        item.forEach(function(img){
+                            result.push(img);
+                        });
+                    }else{
                     result.push(item);
+                    }
                 }
             } else {
                 result.push(item);

--- a/src/extensions/default/BrambleUrlCodeHints/main.js
+++ b/src/extensions/default/BrambleUrlCodeHints/main.js
@@ -178,9 +178,7 @@ define(function (require, exports, module) {
 
                         return deferred.promise();
                     }, false)
-                    .done(function() {
-                        callback();
-                    })
+                    .done(callback)
                     .fail(function() {
                         callback(new Error("unable to find image paths"));
                     });

--- a/src/extensions/default/BrambleUrlCodeHints/main.js
+++ b/src/extensions/default/BrambleUrlCodeHints/main.js
@@ -39,7 +39,6 @@ define(function (require, exports, module) {
         ExtensionUtils  = brackets.getModule("utils/ExtensionUtils"),
         EditorManager   = brackets.getModule("editor/EditorManager"),
         Path            = brackets.getModule("filesystem/impls/filer/FilerUtils").Path,
-        Content         = brackets.getModule("filesystem/impls/filer/lib/content"),
         StartupState    = brackets.getModule("bramble/StartupState"),
         Camera          = require("camera/index"),
         Selfie          = require("selfie"),
@@ -157,8 +156,7 @@ define(function (require, exports, module) {
                         var filename;
 
                         if (!entry._isDirectory) {
-                            if (ProjectManager.shouldShow(entry) &&
-                                Content.isImage(Path.extname(entry._name))) {
+                            if (ProjectManager.shouldShow(entry)) {
                                 // code hints show the unencoded string so the
                                 // choices are easier to read.  The encoded string
                                 // will still be inserted into the editor.

--- a/src/extensions/default/BrambleUrlCodeHints/main.js
+++ b/src/extensions/default/BrambleUrlCodeHints/main.js
@@ -29,6 +29,7 @@ define(function (require, exports, module) {
 
     // Brackets modules
     var AppInit         = brackets.getModule("utils/AppInit"),
+        Async           = brackets.getModule("utils/Async"),
         CodeHintManager = brackets.getModule("editor/CodeHintManager"),
         CSSUtils        = brackets.getModule("language/CSSUtils"),
         FileSystem      = brackets.getModule("filesystem/FileSystem"),
@@ -39,6 +40,7 @@ define(function (require, exports, module) {
         EditorManager   = brackets.getModule("editor/EditorManager"),
         Path            = brackets.getModule("filesystem/impls/filer/FilerUtils").Path,
         Content         = brackets.getModule("filesystem/impls/filer/lib/content"),
+        StartupState    = brackets.getModule("bramble/StartupState"),
         Camera          = require("camera/index"),
         Selfie          = require("selfie"),
 
@@ -63,15 +65,15 @@ define(function (require, exports, module) {
      * @return {Array.<string>|$.Deferred} The (possibly deferred) hints.
      */
     BrambleUrlCodeHints.prototype._getUrlList = function (query) {
-        var directory,
-            doc,
+        var doc,
             docDir,
             queryDir = "",
             queryUrl,
             result = [],
             self,
             targetDir,
-            unfiltered = [];
+            unfiltered = [],
+            projectRoot = StartupState.project("root");
 
         doc = this.editor && this.editor.document;
         if (!doc || !doc.file) {
@@ -113,7 +115,6 @@ define(function (require, exports, module) {
         // valid and re-used from cache. Filtering based on user input is done outside
         // of this method. When user moves to a new folder, then the cache is deleted,
         // and file/folder info for new folder is then retrieved.
-
         if (this.cachedHints) {
             // url hints have been cached, so determine if they're stale
             if (!this.cachedHints.query ||
@@ -132,7 +133,6 @@ define(function (require, exports, module) {
             unfiltered = this.cachedHints.unfiltered;
 
         } else {
-            directory = FileSystem.getDirectoryForPath(targetDir);
             self = this;
 
             if (self.cachedHints && self.cachedHints.deferred) {
@@ -144,64 +144,60 @@ define(function (require, exports, module) {
             self.cachedHints.unfiltered = [];
             self.cachedHints.imageUrl = self.imageUrl;
 
-            directory.getContents(function (err, contents) {
-                var currentDeferred, entryStr, syncResults;
+            function deepWalk(path, parentPath, callback) {
+                var directory = FileSystem.getDirectoryForPath(Path.join(parentPath, path));
+
+                directory.getContents(function (err, contents) {
+                    if(err) {
+                        return callback(err);
+                    }
+
+                    Async.doSequentially(contents, function(entry) {
+                        var deferred = new $.Deferred();
+                        var filename;
+
+                        if (!entry._isDirectory) {
+                            if (ProjectManager.shouldShow(entry) &&
+                                Content.isImage(Path.extname(entry._name))) {
+                                // code hints show the unencoded string so the
+                                // choices are easier to read.  The encoded string
+                                // will still be inserted into the editor.
+                                filename = Path.join(parentPath, path, entry._name);
+                                filename = filename.replace(projectRoot + "/", "");
+                                unfiltered.push(filename);
+                            }
+                            return deferred.resolve().promise();
+                        }
+
+                        deepWalk(entry._name, Path.join(parentPath, path), function(err) {
+                            if(err) {
+                                return deferred.reject();
+                            }
+                            deferred.resolve();
+                        });
+
+                        return deferred.promise();
+                    }, false)
+                    .done(function() {
+                        callback();
+                    })
+                    .fail(function() {
+                        callback(new Error("unable to find image paths"));
+                    });
+                });
+            }
+
+            deepWalk(targetDir, queryDir, function(err, contents) {
+                var currentDeferred = self.cachedHints.deferred;
+                var syncResults;
+
                 if(err) {
+                    console.log("[Bramble Error] couldn't find image paths:", err);
+                    if (currentDeferred && currentDeferred.state() === "pending") {
+                        currentDeferred.reject();
+                    }
                     return;
                 }
-
-                contents.forEach(function (entry) {
-                    if (!ProjectManager.shouldShow(entry)) {
-                        return;
-                    }
-
-                    function getFilesRecursively(targetDir, callback) {
-                        var directory = FileSystem.getDirectoryForPath(targetDir);
-                        var unfiltered = [];
-                        directory.getContents(function (err, contents) {
-                            var currentDeferred, entryStr, syncResults;
-                            if(err) {
-                                callback(err);
-                            }
-                            contents.forEach(function (entry) {
-                                if (!ProjectManager.shouldShow(entry)) {
-                                    callback();
-                                }
-                                if (entry._isDirectory) {
-                                    var fPath = entry._path;
-                                    getFilesRecursively(fPath, function (err, files) {
-                                        if (err) {
-                                            callback(err);
-                                            return;
-                                        }
-                                        unfiltered.push(files);
-                                    });
-                                } 
-                                else {
-                                    entryStr = entry._name;
-                                    unfiltered.push(entryStr);
-                                }
-                            });
-                        });
-                        callback(null, unfiltered);
-                    }
-                    // convert to doc relative path
-                    entryStr = queryDir + entry._name;
-                    // walk of the files recursively
-                    if (entry._isDirectory) {
-                        var fPath = entry._path;
-                        getFilesRecursively(fPath, function(err, data) {
-                            if (err) {
-                                return;
-                            }
-                            unfiltered.push(data);
-                        });
-                    }
-                    // code hints show the unencoded string so the
-                    // choices are easier to read.  The encoded string
-                    // will still be inserted into the editor.
-                    unfiltered.push(entryStr);
-                });
 
                 self.cachedHints.unfiltered = unfiltered;
                 self.cachedHints.query      = query;
@@ -247,14 +243,12 @@ define(function (require, exports, module) {
         // add file/folder entries
         unfiltered.forEach(function (item) {
             if(isImage) {
-                if(Content.isImage(Path.extname(item))) {
-                    if(Array.isArray(item)){
-                        item.forEach(function(img){
-                            result.push(img);
-                        });
-                    }else{
+                if(Array.isArray(item)){
+                    item.forEach(function(img){
+                        result.push(img);
+                    });
+                } else {
                     result.push(item);
-                    }
                 }
             } else {
                 result.push(item);


### PR DESCRIPTION
This builds on and completes work begun by @Taguiar and @simon66 in https://github.com/mozilla/brackets/pull/726 and fixes #514 and https://github.com/mozilla/thimble.mozilla.org/issues/1927.

Here is what it looks like when you run it:

![screen shot 2017-06-06 at 2 08 25 pm](https://user-images.githubusercontent.com/427398/26844935-0ad1b22a-4ac3-11e7-8437-b55c1b67f017.png)
