### PR TITLE
Fix mozilla/thimble.mozilla.org#889: Remove root folder thimble-project if exists

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,7 @@ The `options` object allows you to configure Bramble:
  * `disableUIState`: `<Boolean>` by default, UI state is kept between sessions.  This disables it (and clears old values), and uses the defaults from Bramble.
  * `autoRecoverFileSystem`: `<Boolean>` whether to try and autorecover the filesystem on failure (see `Bramble.formatFileSystem` above).
  * `debug`: `<Boolean>` whether to log debug info.
+* `zipFilenamePrefix`: `<String>` the prefix name to use for project zip files, or `"thimble-project"` by default.
 
 ## Bramble.mount(root[, filename])
 

--- a/src/bramble/client/main.js
+++ b/src/bramble/client/main.js
@@ -465,7 +465,9 @@ define([
                                     autoUpdate: _state.autoUpdate,
                                     openSVGasXML: _state.openSVGasXML,
                                     allowJavaScript: _state.allowJavaScript,
-                                    allowWhiteSpace: _state.allowWhiteSpace
+                                    allowWhiteSpace: _state.allowWhiteSpace,
+                                    // Allow overriding the default name for project zip files
+                                    zipFilenamePrefix: options.zipFilenamePrefix
                                 }
                             };
                             _brambleWindow.postMessage(JSON.stringify(initMessage), _iframe.src);

--- a/src/document/DocumentCommandHandlers.js
+++ b/src/document/DocumentCommandHandlers.js
@@ -1633,7 +1633,11 @@ define(function (require, exports, module) {
             }
 
             if (stats.type === "DIRECTORY") {
-                return ArchiveUtils.archive(path);
+                return ArchiveUtils.archive(path, Path.basename(path), function(err) {
+                    if (err) {
+                        showErrorDialog(err);
+                    }
+                });
             }
 
             // Prepare file for download

--- a/src/extensions/default/bramble/main.js
+++ b/src/extensions/default/bramble/main.js
@@ -175,7 +175,8 @@ define(function (require, exports, module) {
         // to Brackets that it can keep going, which will pick this up.
         BrambleStartupState.project.init({
             root: data.mount.root,
-            filename: data.mount.filename
+            filename: data.mount.filename,
+            zipFilenamePrefix: data.state.zipFilenamePrefix ||  "thimble-project"
         });
 
         // Set initial UI state values (if present)

--- a/src/filesystem/impls/filer/ArchiveUtils.js
+++ b/src/filesystem/impls/filer/ArchiveUtils.js
@@ -85,7 +85,7 @@ define(function (require, exports, module) {
                 }
 
                 var isDir = file.options.dir;
-                var filename = removeProjectFolder(file.name);
+                var filename = removeThimbleProjectFolder(file.name);
                 filenames.push({
                     absPath: Path.join(destination, filename),
                     isDirectory: isDir,
@@ -93,10 +93,10 @@ define(function (require, exports, module) {
                 });
             });
 
-            function removeProjectFolder(path){
-                // Nuke root folder thimble-project/ if exists
-                var regex = /^thimble\-project\//g;
-                return path.replace(regex, "");
+            function removeThimbleProjectFolder(path){
+                // Nuke root folder `thimble-project/` if exists so that project zip files
+                // can be re-imported without adding an unnecessary folder.
+                return path.replace(/^thimble\-project\//, "");
             }
 
             function decompress(path, callback) {

--- a/src/filesystem/impls/filer/ArchiveUtils.js
+++ b/src/filesystem/impls/filer/ArchiveUtils.js
@@ -85,12 +85,19 @@ define(function (require, exports, module) {
                 }
 
                 var isDir = file.options.dir;
+                var filename = removeProjectFolder(file.name);
                 filenames.push({
-                    absPath: Path.join(destination, file.name),
+                    absPath: Path.join(destination, filename),
                     isDirectory: isDir,
                     data: isDir ? null : new Buffer(file.asArrayBuffer())
                 });
             });
+
+            function removeProjectFolder(path){
+                // Nuke root folder thimble-project/ if exists
+                var regex = /^thimble\-project\//g;
+                return path.replace(regex, "");
+            }
 
             function decompress(path, callback) {
                 var basedir = Path.dirname(path.absPath);
@@ -152,7 +159,7 @@ define(function (require, exports, module) {
 
         function toRelProjectPath(path) {
             // Make path relative within the zip, rooted in a `project/` dir
-            return path.replace(rootRegex, "project/");
+            return path.replace(rootRegex, "thimble-project/");
         }
 
         function addFile(path, callback) {

--- a/src/filesystem/impls/filer/ArchiveUtils.js
+++ b/src/filesystem/impls/filer/ArchiveUtils.js
@@ -208,7 +208,7 @@ define(function (require, exports, module) {
             // Prepare folder for download
             var compressed = jszip.generate({type: 'arraybuffer'});
             var blob = new Blob([compressed], {type: "application/zip"});
-            saveAs(blob, "project.zip");
+            saveAs(blob, "thimble-project.zip");
             callback();
         });
     }


### PR DESCRIPTION
This builds on and completes the work started by @simon66 in https://github.com/mozilla/brackets/pull/724.  I've made a few additions/changes:

* rebased on master
* added the ability to configure the name of the zip filename for a project archive, defaults to `thimble-project`
* changed the `Download` action for folders such that it uses the folder's name as the zip filename (e.g., downloading a folder named `images` will produce `images.zip`)

For testing, try these actions:

* Create a new project with some folders
* Try downloading a single file (right click), you should get that file downloaded
* Try downloading a folder (right click), you should get `{folder-name}.zip` with all the contents
* Try calling `bramble.export()` and you should get a `thimble-project.zip` file.
* Delete all your files
* Try dragging `thimble-project.zip` back into your filetree, and it should expand in the root vs. making a `thimble-project/` dir
* Try dragging the same `thimble-project.zip` deep into the file tree (e.g., hover over dirs to open them) and drop on a sub-dir.  It should expand the project again at the current location vs. the root, without including `thimble-project/` as a dir.