### PR TITLE
Styling fixes for :focused files and move to dialog

### DIFF
--- a/src/extensions/default/bramble-move-file/styles/style.less
+++ b/src/extensions/default/bramble-move-file/styles/style.less
@@ -4,22 +4,23 @@
 }
 
 .move-to-dialog {
-    font-size: 15px;
+    font-size: 16px;
+    font-family: "Open Sans", "Helvetica Neue", helvetica, sans-serif;
+    font-weight: 400;
+
+    strong {
+      color: #333;
+    }
 }
 
 .move-to-dialog .directory {
-    margin-bottom: 6px;
+    margin: 6px 0;
     display: block;
-}
-
-.move-to-dialog .directory:last-child {
-    margin-bottom: 0px;
 }
 
 .move-to-dialog .directory-name {
     display: inline-block;
-    padding: 6px 10px;
-    border-radius: 2px;
+    padding: 12px 15px;
 }
 
 .move-to-dialog .directory-name:hover {
@@ -27,24 +28,20 @@
     cursor: pointer;
 }
 
-.dark .move-to-dialog .directory-name:hover {
-    background-color: rgba(255,255,255,.05);
-}
-
 .move-to-dialog .active-directory, .move-to-dialog .active-directory:hover {
     background-color: rgba(0,0,0,.1);
 }
 
-.dark .move-to-dialog .active-directory, .dark .move-to-dialog .active-directory:hover {
-    background-color: rgba(255,255,255,.1);
+.move-to-dialog .active-directory strong {
+    font-weight: 600;
 }
 
 .move-to-dialog .folder-icon {
     background: url("../images/folder-icon-black.svg") no-repeat left center;
-    opacity: 0.7;
-    padding-left: 20px;
+    opacity: 0.5;
+    padding-left: 25px;
 }
 
-.dark .move-to-dialog .folder-icon {
-    background: url("../images/folder-icon-white.svg") no-repeat left center;
+.move-to-dialog .active-directory .folder-icon {
+    opacity: 0.8;
 }

--- a/src/styles/brackets_patterns_override.less
+++ b/src/styles/brackets_patterns_override.less
@@ -45,7 +45,7 @@ a {
 a:hover {
     color: @bc-text-link;
     text-decoration: underline;
-    
+
     .dark & {
         color: @dark-bc-text-link;
     }
@@ -54,12 +54,10 @@ a:hover {
 a:focus {
     color: @bc-text-link;
     outline: 0;
-    box-shadow: 0 0 0 1px @bc-btn-border-focused-glow;
     text-decoration: none;
 
     .dark & {
         color: @dark-bc-text-link;
-        box-shadow: 0 0 0 1px @dark-bc-btn-border-focused;
     }
 }
 
@@ -89,7 +87,7 @@ a:focus {
     background-color: transparent;
 
     text-shadow: 0 1px 2px @bc-shadow-large;
-    
+
     .dark & {
         text-shadow: 0 1px 2px @dark-bc-shadow-large;
     }
@@ -368,7 +366,7 @@ a:focus {
         // Offset for better alignment with button
         top: 34px;
         margin-top: 0;
-        
+
         // Fix for #4593: don't let narrow parent (menubar item) cause text wrap at the float boundary between
         // the menu item label and keyboard shortcut. This takes away the "gotta get narrower" pressure.
         // This technique won't work on all browsers; see comments in #4593 for alternative options.
@@ -596,7 +594,7 @@ a:focus {
     &.dropdown-menu:focus {
         outline: none;
     }
-    
+
     &.dropdown-menu {
         border: none;
         border-radius: @bc-border-radius;
@@ -614,11 +612,11 @@ a:focus {
             box-shadow: 0 3px 9px @dark-bc-shadow;
         }
     }
-    
+
     &.dropdown-menu li a {
         padding: 1px 15px 1px 15px;
         color: @bc-menu-text;
-        
+
         .dark & {
             color: @dark-bc-menu-text;
         }
@@ -631,11 +629,11 @@ a:focus {
             }
         }
     }
-    
+
     &.dropdown-menu .stylesheet-link {
         display: block;
     }
-    
+
     &.dropdown-menu a.selected {
         background: @bc-bg-highlight;
         color: @bc-menu-text !important;
@@ -659,7 +657,7 @@ a:focus {
             display: inline-block;
         }
     }
-    
+
     &.dropdown-menu a:hover {
         /* toggle checkmark visibility */
         &.checked::before {
@@ -683,12 +681,12 @@ a:focus {
     transform-origin: 0 100%;
     height: auto;
     max-height: 80%;
-    
+
     // Improve how bottom of the dropdown joins with top of status bar button
     margin-top: -6px;
     border-bottom-left-radius: 0;
     border-bottom-right-radius: 0;
-    
+
     li a .default-language {
         font-style: italic;
         color: @bc-text-quiet;
@@ -716,7 +714,7 @@ a:focus {
     .stylesheet-link, .stylesheet-name {
         white-space: nowrap;
     }
-    
+
     .stylesheet-name {
         color: @bc-text;
 
@@ -724,7 +722,7 @@ a:focus {
             color: @dark-bc-text;
         }
     }
-    
+
     .stylesheet-dir {
         color: @bc-text-quiet;
 
@@ -981,15 +979,15 @@ a[href^="http"] {
             // Enable text selection
             cursor: auto;
             .user-select(text);
-            
+
             h3 {
                 font-weight: normal;
                 margin: 0 0 10px;
             }
-            
+
             ul {
                 margin-bottom: 0 0 20px;
-                
+
                 > li {
                     margin-bottom: 10px;
                 }
@@ -1027,7 +1025,7 @@ a[href^="http"] {
 .extension-manager-dialog {
     background-color: @bc-panel-bg-promoted;
     width: 760px;
-    
+
     .dark & {
         background-color: @dark-bc-panel-bg-promoted;
     }
@@ -1035,7 +1033,7 @@ a[href^="http"] {
     .modal-header {
         border-bottom: none;
         padding: 0;
-        
+
         .nav-tabs {
             margin: 0;
             border-color: @bc-panel-separator;
@@ -1107,7 +1105,7 @@ a[href^="http"] {
                     border-color: @dark-bc-btn-border @dark-bc-btn-border transparent @dark-bc-btn-border;
                 }
             }
-            
+
             > .active > a:focus {
                 background-color: @bc-panel-bg;
                 border-color: @bc-btn-border-focused @bc-btn-border-focused transparent @bc-btn-border-focused;
@@ -1189,7 +1187,7 @@ a[href^="http"] {
         overflow-y: scroll;
         background-color: @bc-panel-bg;
         padding: 0;
-        
+
         .dark & {
             background-color: @dark-bc-panel-bg;
         }
@@ -1454,7 +1452,7 @@ input[type="color"],
     &.top .tooltip-arrow {
         border-top-color: @bc-menu-bg;
         left: 50%;
-        
+
         .dark & {
             border-top-color: @dark-bc-menu-bg;
         }
@@ -1462,7 +1460,7 @@ input[type="color"],
     &.right .tooltip-arrow {
         border-right-color: @bc-menu-bg;
         top: 15px;
-        
+
         .dark & {
             border-right-color: @dark-bc-menu-bg;
         }
@@ -1470,7 +1468,7 @@ input[type="color"],
     &.left .tooltip-arrow {
         border-left-color: @bc-menu-bg;
         top: 15px;
-        
+
         .dark & {
             border-left-color: @dark-bc-menu-bg;
         }
@@ -1478,7 +1476,7 @@ input[type="color"],
     &.bottom .tooltip-arrow {
         border-bottom-color: @bc-menu-bg;
         left: 50%;
-        
+
         .dark & {
             border-bottom-color: @dark-bc-menu-bg;
         }
@@ -1582,7 +1580,7 @@ input[type="color"],
             color: @dark-bc-text-alt;
         }
     }
-    
+
     &:active:not([disabled]) {
         background-image: none;
         background-color: @bc-btn-bg-down;
@@ -1645,7 +1643,7 @@ input[type="color"],
             }
         }
     }
-    
+
     // Update Button Type
     &.update {
         background-color: @bc-secondary-btn-bg;
@@ -1654,7 +1652,7 @@ input[type="color"],
         color: @bc-text-alt;
         font-weight: @font-weight-semibold;
         text-shadow: 0 -1px 0 @bc-shadow-small;
-        
+
         .dark & {
             background-color: @dark-bc-secondary-btn-bg;
             border-color: @dark-bc-secondary-btn-border;
@@ -1895,13 +1893,13 @@ select {
     &:active {
         background-color: @bc-btn-bg-down;
         box-shadow: inset 0 1px 0 @bc-shadow-small;
-        
+
         .dark & {
             background-color: @dark-bc-btn-bg-down;
             box-shadow: inset 0 1px 0 @dark-bc-shadow-small;
         }
     }
-    
+
     > option { // Windows (but not Mac) lets you style the dropdown items
         background-color: @bc-menu-bg;
         color: @bc-menu-text;
@@ -1964,7 +1962,7 @@ code {
 .dropdown-menu {
     background-color: @bc-menu-bg;
     color: @bc-menu-text;
-    
+
     .dark & {
         background-color: @dark-bc-menu-bg;
         color: @dark-bc-menu-text;
@@ -1983,7 +1981,7 @@ code {
 .form-horizontal {
     .controls {
         margin-left: 170px;
-        
+
         input[type='checkbox'] {
              margin-top: 8px;
         }


### PR DESCRIPTION
Couple of small fixes here:

* Fixed **Move To** dialog styling
* Removed blue border from elements with ":focus" in the file tree.

**Test Move To Dialog**
* Right-click a file and select **Move to** in your project in the dark and light themes
  * Items in the dialog should be styled the same regardless of theme and be clearly legible

**Test Outline**
* Switch to the dark theme
* In the file view, click and hold one of the files
  * No blue border should appear around the item

Fixes https://github.com/mozilla/thimble.mozilla.org/issues/2282
Fixes https://github.com/mozilla/thimble.mozilla.org/issues/2279