### PR TITLE
Fix #788: switch to npm version of EventEmitter

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -31,9 +31,6 @@
 [submodule "src/thirdparty/slowparse"]
 	path = src/thirdparty/slowparse
 	url = https://github.com/mozilla/slowparse.git
-[submodule "src/bramble/thirdparty/EventEmitter"]
-	path = src/bramble/thirdparty/EventEmitter
-	url = https://github.com/Wolfy87/EventEmitter.git
 [submodule "src/thirdparty/jszip"]
 	path = src/thirdparty/jszip
 	url = https://github.com/Stuk/jszip.git

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -222,6 +222,9 @@ module.exports = function (grunt) {
                 options: {
                     name: 'thirdparty/almond',
                     baseUrl: 'src',
+                    paths: {
+                        "EventEmitter": "../node_modules/wolfy87-eventemitter/EventEmitter.min"
+                    },
                     optimize: 'uglify2',
                     preserveLicenseComments: false,
                     useStrict: true,

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
         "phantomjs": "1.9.18",
         "q": "1.4.1",
         "semver": "^4.1.0",
+        "wolfy87-eventemitter": "^5.1.0",
         "xmldoc": "^0.1.2"
     },
     "devDependencies": {

--- a/src/bramble/client/main.js
+++ b/src/bramble/client/main.js
@@ -21,13 +21,18 @@
  *
  */
 
-/*global define, HTMLElement, MessageChannel, addEventListener*/
+/*global require, define, HTMLElement, MessageChannel, addEventListener*/
+require.config({
+    paths: {
+        "EventEmitter": "../node_modules/wolfy87-eventemitter/EventEmitter.min"
+    }
+});
 
 define([
     // Change this to filer vs. filer.min if you need to debug Filer
     "thirdparty/filer/dist/filer.min",
     "bramble/ChannelUtils",
-    "bramble/thirdparty/EventEmitter/EventEmitter.min",
+    "EventEmitter",
     "bramble/client/StateManager",
     "bramble/client/ProjectStats"
 ], function(Filer, ChannelUtils, EventEmitter, StateManager, ProjectStats) {


### PR DESCRIPTION
Removes the old `EventEmitter` submodule and replaces it with a newer one via npm.