### PR TITLE
Auto resize PNG and JPG images that are more than 250K

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -199,7 +199,8 @@ module.exports = function (grunt) {
                     paths: {
                         // In various places in the code, it's useful to know if this is a dev vs. prod env.
                         // See src/main.js default dev loading in src/ builds.
-                        "envConfig": "bramble/config/config.prod"
+                        "envConfig": "bramble/config/config.prod",
+                        "Pica": "../node_modules/pica/dist/pica.min"
                     },
                     // brackets.js should not be loaded until after polyfills defined in "utils/Compatibility"
                     // so explicitly include it in main.js

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
         "load-grunt-tasks": "3.5.0",
         "lodash": "4.15.0",
         "phantomjs": "1.9.18",
+        "pica": "^3.0.4",
         "q": "1.4.1",
         "semver": "^4.1.0",
         "wolfy87-eventemitter": "^5.1.0",

--- a/src/filesystem/impls/filer/FilerFileSystem.js
+++ b/src/filesystem/impls/filer/FilerFileSystem.js
@@ -295,7 +295,7 @@ define(function (require, exports, module) {
                     }
 
                     // If this is a big image (>250K), resize it first
-                    if(Content.isResizableImage(ext) && ImageResizer.isImageTooLarge(data.length)) {
+                    if(Content.isResizableImage(ext) && Content.isImageTooLarge(data.length)) {
                         ImageResizer.resize(path, data, function(err, resized) {
                             if(err) {
                                 return callback(err);

--- a/src/filesystem/impls/filer/FilerFileSystem.js
+++ b/src/filesystem/impls/filer/FilerFileSystem.js
@@ -13,7 +13,8 @@ define(function (require, exports, module) {
         Content         = require("filesystem/impls/filer/lib/content"),
         Async           = require("utils/Async"),
         BrambleEvents   = require("bramble/BrambleEvents"),
-        FileSystemCache = require("filesystem/impls/filer/FileSystemCache");
+        FileSystemCache = require("filesystem/impls/filer/FileSystemCache"),
+        ImageResizer    = require("filesystem/impls/filer/lib/ImageResizer");
 
     var fs              = BracketsFiler.fs(),
         Path            = BracketsFiler.Path,
@@ -285,10 +286,24 @@ define(function (require, exports, module) {
             Async.doSequentially([
                 // We need to rewrite and cache first, before we transfer ownership of the data
                 function step1RewriteAndCache(callback) {
+                    var ext = Path.extname(path);
+
                     // Add a BLOB cache record for this filename
                     // only if it's not an HTML file
-                    if(Content.isHTML(Path.extname(path))) {
-                        callback();
+                    if(Content.isHTML(ext)) {
+                        return callback();
+                    }
+
+                    // If this is a big image (>250K), resize it first
+                    if(Content.isResizableImage(ext) && ImageResizer.isImageTooLarge(data.length)) {
+                        ImageResizer.resize(path, data, function(err, resized) {
+                            if(err) {
+                                return callback(err);
+                            }
+
+                            data = resized;
+                            Handlers.handleFile(path, data, callback);
+                        });
                     } else {
                         Handlers.handleFile(path, data, callback);
                     }

--- a/src/filesystem/impls/filer/lib/FileImport.js
+++ b/src/filesystem/impls/filer/lib/FileImport.js
@@ -10,12 +10,18 @@ define(function (require, exports, module) {
         FileSystemCache     = require("filesystem/impls/filer/FileSystemCache"),
         BrambleStartupState = brackets.getModule("bramble/StartupState");
 
+    // 1 MB
+    var MB = 1024 * 1024;
+
     // 3MB size limit for imported files. If you change this, also change the
     // error message we generate in rejectImport() below!
-    var byteLimit = 3145728;
+    var byteLimit = 3 * MB;
 
     // 5MB size limit for imported archives (zip & tar)
-    var archiveByteLimit = 5242880;
+    var archiveByteLimit = 5 * MB;
+
+    // 12MB size limit for imported image files that can be auto-resized (png, jpg)
+    var resizableImageLimit = 12 * MB;
 
     /**
      * XXXBramble: the Drag and Drop and File APIs are a mess of incompatible
@@ -37,7 +43,8 @@ define(function (require, exports, module) {
     function chooseImportStrategy(source) {
         var options = {
             byteLimit: byteLimit,
-            archiveByteLimit: archiveByteLimit
+            archiveByteLimit: archiveByteLimit,
+            resizableImageLimit: resizableImageLimit
         };
 
         if(source instanceof FileList) {

--- a/src/filesystem/impls/filer/lib/FileImport.js
+++ b/src/filesystem/impls/filer/lib/FileImport.js
@@ -8,20 +8,7 @@ define(function (require, exports, module) {
     var LegacyFileImport    = require("filesystem/impls/filer/lib/LegacyFileImport"),
         WebKitFileImport    = require("filesystem/impls/filer/lib/WebKitFileImport"),
         FileSystemCache     = require("filesystem/impls/filer/FileSystemCache"),
-        BrambleStartupState = brackets.getModule("bramble/StartupState");
-
-    // 1 MB
-    var MB = 1024 * 1024;
-
-    // 3MB size limit for imported files. If you change this, also change the
-    // error message we generate in rejectImport() below!
-    var byteLimit = 3 * MB;
-
-    // 5MB size limit for imported archives (zip & tar)
-    var archiveByteLimit = 5 * MB;
-
-    // 12MB size limit for imported image files that can be auto-resized (png, jpg)
-    var resizableImageLimit = 12 * MB;
+        BrambleStartupState = require("bramble/StartupState");
 
     /**
      * XXXBramble: the Drag and Drop and File APIs are a mess of incompatible
@@ -41,23 +28,17 @@ define(function (require, exports, module) {
      *  - https://developer.mozilla.org/en-US/docs/Web/API/DataTransferItem/webkitGetAsEntry
      */
     function chooseImportStrategy(source) {
-        var options = {
-            byteLimit: byteLimit,
-            archiveByteLimit: archiveByteLimit,
-            resizableImageLimit: resizableImageLimit
-        };
-
         if(source instanceof FileList) {
-            return LegacyFileImport.create(options);
+            return LegacyFileImport.create();
         }
 
         if(source instanceof DataTransfer) {
             if(window.DataTransferItem                            &&
                window.DataTransferItem.prototype.webkitGetAsEntry &&
                window.DataTransferItemList) {
-                return WebKitFileImport.create(options);
+                return WebKitFileImport.create();
             }
-            return LegacyFileImport.create(options);
+            return LegacyFileImport.create();
         }
     }
 

--- a/src/filesystem/impls/filer/lib/ImageResizer.js
+++ b/src/filesystem/impls/filer/lib/ImageResizer.js
@@ -83,10 +83,13 @@ define(function (require, exports, module) {
 
             pica.resize(img, self.canvas)
             .then(function() {
-                self.resizedToBuffer(function(err, buffer) {
+                self.resizedToBuffer(function(err, resizedBuffer) {
                     if(err) {
                         return finish(err);
                     }
+
+                    // Retain this buffer, in case it's the best we can do.
+                    buffer = resizedBuffer;
 
                     // Too big?
                     if(buffer.length > TARGET_SIZE_KB + TOLERANCE_KB) {

--- a/src/filesystem/impls/filer/lib/ImageResizer.js
+++ b/src/filesystem/impls/filer/lib/ImageResizer.js
@@ -1,0 +1,88 @@
+/*jslint vars: true, plusplus: true, devel: true, nomen: true, regexp: true, indent: 4, maxerr: 50 */
+/*global define */
+define(function (require, exports, module) {
+    "use strict";
+
+    var pica = require("Pica")();
+
+    var Content = require("filesystem/impls/filer/lib/content");
+    var Path = require("filesystem/impls/filer/FilerUtils").Path;
+    var decodePath = require("filesystem/impls/filer/FilerUtils").decodePath;
+    var base64ToBuffer = require("filesystem/impls/filer/FilerUtils").base64ToBuffer
+
+    function ImageResizer(path, data) {
+        this.path = decodePath(path);
+        this.type = Content.mimeFromExt(Path.extname(this.path));
+        this.blob = new Blob([data], {type: this.type});
+        this.url = URL.createObjectURL(this.blob);
+        this.canvas = document.createElement('canvas');
+    }
+    ImageResizer.prototype.cleanup = function() {
+        URL.revokeObjectURL(this.url);
+    };
+    ImageResizer.prototype.resize = function(callback) {
+        var self = this;
+        var scalingFactor = 0.75;
+        var buffer;
+        var passes = 0;
+
+        function finish(err, buffer) {
+            self.cleanup();
+            callback(err, buffer);
+        }
+
+        function resizePass() {
+            console.log("resizePass", passes, scalingFactor);
+
+            if(passes++ > 5) {
+                finish(null, buffer);
+            }
+
+            self.canvas.width = img.width * scalingFactor;
+            self.canvas.height = img.height * scalingFactor;
+
+            console.log("width", self.canvas.width, "height", self.canvas.height);
+
+            pica.resize(img, self.canvas)
+            .then(function() {
+                var base64Str = self.canvas.toDataURL(self.type).split(',')[1];
+                buffer = base64ToBuffer(base64Str);
+
+                console.log("result", buffer.length);
+
+                if(isImageTooLarge(buffer.length)) {
+                    scalingFactor /= 1.25;
+                    return resizePass();
+                }
+
+                finish(null, buffer);
+            })
+            .catch(finish);
+        }
+
+        var img = new Image();
+        img.onload = resizePass;
+        img.onerror = function() {
+            finish(new Error("Unable to load image for resizing"));
+        };
+        img.src = self.url;
+    };
+
+    /**
+     * Resize an image and write back to the filesystem
+     */
+    function resize(path, data, callback) {
+        var resizer = new ImageResizer(path, data);
+        resizer.resize(callback);
+    }
+
+    /**
+     * Test if image data size is too big (250K)
+     */
+    function isImageTooLarge(size) {
+        return size > 250 * 1024;
+    }
+
+    exports.resize = resize;
+    exports.isImageTooLarge = isImageTooLarge;
+});

--- a/src/filesystem/impls/filer/lib/ImageResizer.js
+++ b/src/filesystem/impls/filer/lib/ImageResizer.js
@@ -8,7 +8,7 @@ define(function (require, exports, module) {
     var Content = require("filesystem/impls/filer/lib/content");
     var Path = require("filesystem/impls/filer/FilerUtils").Path;
     var decodePath = require("filesystem/impls/filer/FilerUtils").decodePath;
-    var base64ToBuffer = require("filesystem/impls/filer/FilerUtils").base64ToBuffer
+    var base64ToBuffer = require("filesystem/impls/filer/FilerUtils").base64ToBuffer;
 
     function ImageResizer(path, data) {
         this.path = decodePath(path);

--- a/src/filesystem/impls/filer/lib/ImageResizer.js
+++ b/src/filesystem/impls/filer/lib/ImageResizer.js
@@ -13,6 +13,7 @@ define(function (require, exports, module) {
     function ImageResizer(path, data) {
         this.path = decodePath(path);
         this.type = Content.mimeFromExt(Path.extname(this.path));
+        this.size = data.length;
         this.blob = new Blob([data], {type: this.type});
         this.url = URL.createObjectURL(this.blob);
         this.canvas = document.createElement('canvas');
@@ -23,12 +24,14 @@ define(function (require, exports, module) {
     ImageResizer.prototype.resize = function(callback) {
         var self = this;
         var buffer;
-        var scale = 1; // initial scale factor of 1 to deal with "only huge because huge dpi" images
-        var step = scale / 2;
+
         var target = 250 * 1024;
         var errorThreshold = 20 * 2014;
         var passes = 0;
         var maxPasses = 5;
+        // do a "best guess" initial scale
+        var scale = Math.sqrt(target/self.size);
+        var step = scale / 2;
 
         function finish(err, buffer) {
             self.cleanup();
@@ -36,7 +39,7 @@ define(function (require, exports, module) {
         }
 
         function resizePass() {
-            console.log("resizePass", passes, scale);
+            console.log("resizePass", passes, "scale", scale);
 
             if(passes++ > maxPasses) {
                 finish(null, buffer);

--- a/src/filesystem/impls/filer/lib/ImageResizer.js
+++ b/src/filesystem/impls/filer/lib/ImageResizer.js
@@ -67,11 +67,9 @@ define(function (require, exports, module) {
             // "cannot" be below target/2 and 3*target/2. If it is, we guessed
             // wrong and should redo our initial guess.
             if (bufferSize < TARGET_SIZE * 0.5) {
-                console.log("wrong initial scale: resulting image is too large")
                 return true;
             }
             if (bufferSize > TARGET_SIZE * 0.66) {
-                console.log("wrong initial scale: resulting image is too small")
                 return true;
             }
             return false;
@@ -87,8 +85,6 @@ define(function (require, exports, module) {
             // at which to likely hit our target filesize?
             scale = Math.sqrt(TARGET_SIZE / DERIVED_ORIGINAL_SIZE);
             step = scale / 2;
-
-             console.log("recomputed initial guess:", scale)
         }
 
         function finish(err, buffer) {
@@ -99,16 +95,12 @@ define(function (require, exports, module) {
         }
 
         function resizePass() {
-            console.log("resizePass", passes, "scale", scale);
-
             if(passes++ > MAX_RESIZE_PASSES) {
                 return finish(null, buffer);
             }
 
             self.canvas.width = img.width * scale;
             self.canvas.height = img.height * scale;
-
-            console.log("width", self.canvas.width, "height", self.canvas.height);
 
             pica.resize(img, self.canvas)
             .then(function() {
@@ -123,8 +115,6 @@ define(function (require, exports, module) {
 
                     // Too big?
                     if(bufferSize > TARGET_SIZE + Sizes.IMAGE_RESIZE_TOLERANCE_KB) {
-                        console.log("Resized image too big", bufferSize);
-
                         if (passes===1 && unexpectedInitialGuess(bufferSize)) {
                             redoInitialGuess(scale, bufferSize);
                         } else {
@@ -137,8 +127,6 @@ define(function (require, exports, module) {
 
                     // Smaller than necessary?
                     else if(bufferSize < TARGET_SIZE - Sizes.IMAGE_RESIZE_TOLERANCE_KB) {
-                        console.log("Resized image too small", bufferSize);
-
                         if (passes===1 && unexpectedInitialGuess(bufferSize)) {
                             redoInitialGuess(scale, bufferSize);
                         } else {
@@ -149,6 +137,7 @@ define(function (require, exports, module) {
                         resizePass();
                     }
 
+                    // We're done, use this one
                     else {
                         finish(null, buffer);
                     }

--- a/src/filesystem/impls/filer/lib/LegacyFileImport.js
+++ b/src/filesystem/impls/filer/lib/LegacyFileImport.js
@@ -39,24 +39,13 @@ define(function (require, exports, module) {
         Filer           = require("filesystem/impls/filer/BracketsFiler"),
         Path            = Filer.Path,
         Content         = require("filesystem/impls/filer/lib/content"),
-        LanguageManager = require("language/LanguageManager"),
-        StartupState    = require("bramble/StartupState"),
-        ArchiveUtils    = require("filesystem/impls/filer/ArchiveUtils"),
-        FilerUtils      = require("filesystem/impls/filer/FilerUtils"),
-        ImageResizer    = require("filesystem/impls/filer/lib/ImageResizer");
+        ArchiveUtils    = require("filesystem/impls/filer/ArchiveUtils");
 
-    function LegacyFileImport(options) {
-        this.byteLimit = options.byteLimit;
-        this.archiveByteLimit = options.archiveByteLimit;
-        this.resizableImageLimit = options.resizableImageLimit;
-    }
+    function LegacyFileImport(){}
 
     // We want event.dataTransfer.files for legacy browsers.
     LegacyFileImport.prototype.import = function(source, parentPath, callback) {
         var files = source instanceof DataTransfer ? source.files : source;
-        var byteLimit = this.byteLimit;
-        var archiveByteLimit = this.archiveByteLimit;
-        var resizableImageLimit = this.resizableImageLimit;
         var pathList = [];
         var errorList = [];
 
@@ -127,39 +116,6 @@ define(function (require, exports, module) {
             });
         }
 
-        /**
-         * Determine whether we want to import this file at all.  If it's too large
-         * or not a mime type we care about, reject it.
-         */
-        function rejectImport(item) {
-            var ext = Path.extname(item.name);
-            var isArchive = Content.isArchive(ext);
-
-            var sizeLimit;
-            if(Content.isResizableImage(ext)) {
-                sizeLimit = resizableImageLimit;
-            } else if(isArchive) {
-                sizeLimit = archiveByteLimit;
-            } else {
-                sizeLimit = byteLimit;
-            }
-            var sizeLimitMb = (sizeLimit / (1024 * 1024)).toString();
-
-            if (item.size > sizeLimit) {
-                return new Error(StringUtils.format(Strings.DND_MAX_SIZE_EXCEEDED, sizeLimitMb));
-            }
-
-            // If we don't know about this language type, or the OS doesn't think
-            // it's text, reject it.
-            var isSupported = !!LanguageManager.getLanguageForExtension(FilerUtils.normalizeExtension(ext, true));
-            var typeIsText = Content.isTextType(item.type);
-
-            if (isSupported || typeIsText || isArchive) {
-                return null;
-            }
-            return new Error(Strings.DND_UNSUPPORTED_FILE_TYPE);
-        }
-
         function prepareDropPaths(fileList) {
             // Convert FileList object to an Array with all image files first, then CSS
             // followed by HTML files at the end, since we need to write any .css, .js, etc.
@@ -200,7 +156,7 @@ define(function (require, exports, module) {
             var reader = new FileReader();
 
             // Check whether we want to import this file at all before we start.
-            var wasRejected = rejectImport(item);
+            var wasRejected = Content.shouldRejectFile(item.name, item.size);
             if (wasRejected) {
                 errorList.push({path: item.name, error: wasRejected.message});
                 deferred.reject(wasRejected);

--- a/src/filesystem/impls/filer/lib/LegacyFileImport.js
+++ b/src/filesystem/impls/filer/lib/LegacyFileImport.js
@@ -56,6 +56,7 @@ define(function (require, exports, module) {
         var files = source instanceof DataTransfer ? source.files : source;
         var byteLimit = this.byteLimit;
         var archiveByteLimit = this.archiveByteLimit;
+        var resizableImageLimit = this.resizableImageLimit;
         var pathList = [];
         var errorList = [];
 
@@ -134,7 +135,7 @@ define(function (require, exports, module) {
             var ext = Path.extname(item.name);
             var isArchive = Content.isArchive(ext);
 
-            var sizeLimit
+            var sizeLimit;
             if(Content.isResizableImage(ext)) {
                 sizeLimit = resizableImageLimit;
             } else if(isArchive) {

--- a/src/filesystem/impls/filer/lib/LegacyFileImport.js
+++ b/src/filesystem/impls/filer/lib/LegacyFileImport.js
@@ -42,11 +42,13 @@ define(function (require, exports, module) {
         LanguageManager = require("language/LanguageManager"),
         StartupState    = require("bramble/StartupState"),
         ArchiveUtils    = require("filesystem/impls/filer/ArchiveUtils"),
-        FilerUtils      = require("filesystem/impls/filer/FilerUtils");
+        FilerUtils      = require("filesystem/impls/filer/FilerUtils"),
+        ImageResizer    = require("filesystem/impls/filer/lib/ImageResizer");
 
     function LegacyFileImport(options) {
         this.byteLimit = options.byteLimit;
         this.archiveByteLimit = options.archiveByteLimit;
+        this.resizableImageLimit = options.resizableImageLimit;
     }
 
     // We want event.dataTransfer.files for legacy browsers.
@@ -131,7 +133,15 @@ define(function (require, exports, module) {
         function rejectImport(item) {
             var ext = Path.extname(item.name);
             var isArchive = Content.isArchive(ext);
-            var sizeLimit =  isArchive ? archiveByteLimit : byteLimit;
+
+            var sizeLimit
+            if(Content.isResizableImage(ext)) {
+                sizeLimit = resizableImageLimit;
+            } else if(isArchive) {
+                sizeLimit = archiveByteLimit;
+            } else {
+                sizeLimit = byteLimit;
+            }
             var sizeLimitMb = (sizeLimit / (1024 * 1024)).toString();
 
             if (item.size > sizeLimit) {

--- a/src/filesystem/impls/filer/lib/Sizes.js
+++ b/src/filesystem/impls/filer/lib/Sizes.js
@@ -1,0 +1,33 @@
+
+/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
+/*global define*/
+
+define(function (require, exports, module) {
+    "use strict";
+
+    var KB = 1024;
+    var MB = 1024 * KB;
+
+    // 3MB size limit for imported files.
+    var REGULAR_FILE_SIZE_LIMIT_MB = 3 * MB;
+
+    // 5MB size limit for imported archives (zip & tar)
+    var ARCHIVE_FILE_LIMIT_MB = 5 * MB;
+
+    // 12MB size limit for imported image files that can be auto-resized (png, jpg)
+    var RESIZABLE_IMAGE_FILE_LIMIT_MB = 12 * MB;
+
+    // 250KB size limit for images we are auto-resizing (our ideal size)
+    var RESIZED_IMAGE_TARGET_SIZE_KB = 250 * KB;
+
+    // 20KB +/- of error tolerance when we auto-resize images
+    var IMAGE_RESIZE_TOLERANCE_KB = 20 * KB;
+
+    exports.KB = KB;
+    exports.MB = MB;
+    exports.REGULAR_FILE_SIZE_LIMIT_MB = REGULAR_FILE_SIZE_LIMIT_MB;
+    exports.ARCHIVE_FILE_LIMIT_MB = ARCHIVE_FILE_LIMIT_MB;
+    exports.RESIZABLE_IMAGE_FILE_LIMIT_MB = RESIZABLE_IMAGE_FILE_LIMIT_MB;
+    exports.RESIZED_IMAGE_TARGET_SIZE_KB = RESIZED_IMAGE_TARGET_SIZE_KB;
+    exports.IMAGE_RESIZE_TOLERANCE_KB = IMAGE_RESIZE_TOLERANCE_KB;
+});

--- a/src/filesystem/impls/filer/lib/WebKitFileImport.js
+++ b/src/filesystem/impls/filer/lib/WebKitFileImport.js
@@ -35,28 +35,16 @@ define(function (require, exports, module) {
         FileSystem      = require("filesystem/FileSystem"),
         FileUtils       = require("file/FileUtils"),
         Strings         = require("strings"),
-        StringUtils     = require("utils/StringUtils"),
         Filer           = require("filesystem/impls/filer/BracketsFiler"),
         Path            = Filer.Path,
         Content         = require("filesystem/impls/filer/lib/content"),
-        LanguageManager = require("language/LanguageManager"),
-        StartupState    = require("bramble/StartupState"),
-        ArchiveUtils    = require("filesystem/impls/filer/ArchiveUtils"),
-        FilerUtils      = require("filesystem/impls/filer/FilerUtils"),
-        ImageResizer    = require("filesystem/impls/filer/lib/ImageResizer");
+        ArchiveUtils    = require("filesystem/impls/filer/ArchiveUtils");
 
-    function WebKitFileImport(options) {
-        this.byteLimit = options.byteLimit;
-        this.archiveByteLimit = options.archiveByteLimit;
-        this.resizableImageLimit = options.resizableImageLimit;
-    }
+    function WebKitFileImport(){}
 
     // We want event.dataTransfer.items for WebKit style browsers
     WebKitFileImport.prototype.import = function(source, parentPath, callback) {
         var items = source instanceof DataTransfer ? source.items : source;
-        var byteLimit = this.byteLimit;
-        var archiveByteLimit = this.archiveByteLimit;
-        var resizableImageLimit = this.resizableImageLimit;
         var pathList = [];
         var errorList = [];
         var started = 0;
@@ -179,40 +167,6 @@ define(function (require, exports, module) {
             });
         }
 
-        /**
-         * Determine whether we want to import this file at all.  If` it's too large
-         * or not a mime type we care about, reject it.
-         */
-        function rejectImport(filename, size) {
-            var ext = Path.extname(filename);
-            var mime = Content.mimeFromExt(ext);
-            var isArchive = Content.isArchive(ext);
-
-            var sizeLimit;
-            if(Content.isResizableImage(ext)) {
-                sizeLimit = resizableImageLimit;
-            } else if(isArchive) {
-                sizeLimit = archiveByteLimit;
-            } else {
-                sizeLimit = byteLimit;
-            }
-            var sizeLimitMb = (sizeLimit / (1024 * 1024)).toString();
-
-            if (size > sizeLimit) {
-                return new Error(StringUtils.format(Strings.DND_MAX_SIZE_EXCEEDED, sizeLimitMb));
-            }
-
-            // If we don't know about this language type, or the OS doesn't think
-            // it's text, reject it.
-            var isSupported = !!LanguageManager.getLanguageForExtension(FilerUtils.normalizeExtension(ext, true));
-            var typeIsText = Content.isTextType(mime);
-
-            if (isSupported || typeIsText || isArchive) {
-                return null;
-            }
-            return new Error(Strings.DND_UNSUPPORTED_FILE_TYPE);
-        }
-
         function maybeImportDirectory(parentPath, entry, deferred) {
             started++;
             var fullPath = Path.join(parentPath, entry.name);
@@ -250,7 +204,7 @@ define(function (require, exports, module) {
                     }
 
                     // Check whether we want to import this file at all before we start.
-                    var wasRejected = rejectImport(entry.name, buffer.byteLength);
+                    var wasRejected = Content.shouldRejectFile(entry.name, buffer.byteLength);
                     if (wasRejected) {
                         onError(deferred, entry.name, wasRejected);
                         return;

--- a/src/filesystem/impls/filer/lib/WebKitFileImport.js
+++ b/src/filesystem/impls/filer/lib/WebKitFileImport.js
@@ -188,7 +188,7 @@ define(function (require, exports, module) {
             var mime = Content.mimeFromExt(ext);
             var isArchive = Content.isArchive(ext);
 
-            var sizeLimit
+            var sizeLimit;
             if(Content.isResizableImage(ext)) {
                 sizeLimit = resizableImageLimit;
             } else if(isArchive) {

--- a/src/filesystem/impls/filer/lib/content.js
+++ b/src/filesystem/impls/filer/lib/content.js
@@ -6,6 +6,10 @@ define(function (require, exports, module) {
 
     var LanguageManager = require('language/LanguageManager');
     var FilerUtils = require('filesystem/impls/filer/FilerUtils');
+    var Sizes = require("filesystem/impls/filer/lib/Sizes");
+    var Strings = require("strings");
+    var StringUtils = require("utils/StringUtils");
+
 
     function _getLanguageId(ext) {
         ext = FilerUtils.normalizeExtension(ext, true);
@@ -148,6 +152,48 @@ define(function (require, exports, module) {
             }
 
             return /^blob\:/.test(url);
+        },
+
+        /**
+         * Determine whether we want to allow a file to be imported based on name and size.
+         */
+        shouldRejectFile: function(filename, size) {
+            var ext = Path.extname(filename);
+            var mime = this.mimeFromExt(ext);
+            var isArchive = this.isArchive(ext);
+
+            var sizeLimit;
+            if(this.isResizableImage(ext)) {
+                sizeLimit = Sizes.RESIZABLE_IMAGE_FILE_LIMIT_MB;
+            } else if(isArchive) {
+                sizeLimit = Sizes.ARCHIVE_FILE_LIMIT_MB;
+            } else {
+                sizeLimit = Sizes.REGULAR_FILE_SIZE_LIMIT_MB;
+            }
+            var sizeLimitMb = (sizeLimit / (Sizes.MB)).toString();
+
+            if (size > sizeLimit) {
+                return new Error(StringUtils.format(Strings.DND_MAX_SIZE_EXCEEDED, sizeLimitMb));
+            }
+
+            // If we don't know about this language type, or the OS doesn't think
+            // it's text, reject it.
+            var isSupported = !!LanguageManager.getLanguageForExtension(FilerUtils.normalizeExtension(ext, true));
+            var typeIsText = this.isTextType(mime);
+
+            if (isSupported || typeIsText || isArchive) {
+                return null;
+            }
+            return new Error(Strings.DND_UNSUPPORTED_FILE_TYPE);
+        },
+
+
+        /**
+         * Test if image data size is too big (250K)
+         */
+        isImageTooLarge: function(byteLength) {
+            return byteLength > Sizes.RESIZED_IMAGE_TARGET_SIZE_KB;
         }
+
     };
 });

--- a/src/filesystem/impls/filer/lib/content.js
+++ b/src/filesystem/impls/filer/lib/content.js
@@ -19,6 +19,11 @@ define(function (require, exports, module) {
             return id === "image" || id === "svg";
         },
 
+        isResizableImage: function(ext) {
+            ext = FilerUtils.normalizeExtension(ext);
+            return ext === '.png' || ext === '.jpg' || ext === '.jpeg';
+        },
+
         isHTML: function(ext) {
             var id = _getLanguageId(ext);
             return id === "html";

--- a/src/filesystem/impls/filer/lib/content.js
+++ b/src/filesystem/impls/filer/lib/content.js
@@ -5,11 +5,11 @@ define(function (require, exports, module) {
     "use strict";
 
     var LanguageManager = require('language/LanguageManager');
-    var FilerUtils = require('filesystem/impls/filer/FilerUtils');
     var Sizes = require("filesystem/impls/filer/lib/Sizes");
     var Strings = require("strings");
     var StringUtils = require("utils/StringUtils");
-
+    var FilerUtils = require('filesystem/impls/filer/FilerUtils');
+    var Path = FilerUtils.Path;
 
     function _getLanguageId(ext) {
         ext = FilerUtils.normalizeExtension(ext, true);

--- a/src/main.js
+++ b/src/main.js
@@ -37,7 +37,10 @@ require.config({
         // implementations (e.g. cloud-based storage).
         "fileSystemImpl": "filesystem/impls/filer/FilerFileSystem",
 
+        // Image processing libraries
+        "Pica": "../node_modules/pica/dist/pica.min",
         "caman": "thirdparty/caman/caman.full.min",
+
         // In various places in the code, it's useful to know if this is a dev vs. prod env.
         // See Gruntfile for prod override of this to config.prod.js.
         "envConfig": "bramble/config/config.dev"


### PR DESCRIPTION
This is an experiment to try and automatically reduce large images before we write them to disk.

I took an image that is 1.9M on my drive, and tried dragging it in.  It took 6 passes, but it got it down to 195K and it looks great:

![screen shot 2017-06-09 at 2 47 25 pm](https://user-images.githubusercontent.com/427398/26990159-af9299d4-4d23-11e7-8525-1775646d6f80.png)

My logic for doing the passes is not great, and I bet @Pomax could improve things.  I also need to figure out with @flukeout how to message this to the user (we need some kind of info pop-up here).  But the idea is doable, if we iron out the kinks.