### PR TITLE
fix: CSSRewriter should support rewriting @import

### DIFF
--- a/src/filesystem/impls/filer/lib/CSSRewriter.js
+++ b/src/filesystem/impls/filer/lib/CSSRewriter.js
@@ -28,6 +28,7 @@ define(function (require, exports, module) {
         function aggregate(content, callback) {
             var urls = [];
             var urlRegex = new RegExp('url\\([\\\'\\"]?([^\\\'\\"\\)]+)[\\\'\\"]?\\)', 'g');
+            var urlQuotesRegex = new RegExp(/[\"\'](.*?\.css)[\"\']/, 'g');
             var periodRegex = new RegExp('\\.', 'g');
             var forwardSlashRegex = new RegExp('\\/', 'g');
             var dashRegex = new RegExp('\\-', 'g');
@@ -66,6 +67,13 @@ define(function (require, exports, module) {
             }
 
             content.replace(urlRegex, function(_, url) {
+                if(!Content.isRelativeURL(url)) {
+                    return;
+                }
+                urls.push(url);
+            });
+
+            content.replace(urlQuotesRegex, function(_, url) {
                 if(!Content.isRelativeURL(url)) {
                     return;
                 }


### PR DESCRIPTION
Fixes: #446 

Added regex for capturing css file names inside quotes.
This is how it works for strings in quotes -

![cssimport](https://user-images.githubusercontent.com/19590302/27089224-499204a2-5049-11e7-933a-b81b99e675b1.gif)

Initially the browser window is full sized and then I resize the window to a smaller size. The background color changes according to the css rules specified.

Please take a look @humphd!
