### PR TITLE
Add backend and UI for informing users about total project size in Thimble

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,7 +223,8 @@ The `options` object allows you to configure Bramble:
  * `disableUIState`: `<Boolean>` by default, UI state is kept between sessions.  This disables it (and clears old values), and uses the defaults from Bramble.
  * `autoRecoverFileSystem`: `<Boolean>` whether to try and autorecover the filesystem on failure (see `Bramble.formatFileSystem` above).
  * `debug`: `<Boolean>` whether to log debug info.
-* `zipFilenamePrefix`: `<String>` the prefix name to use for project zip files, or `"thimble-project"` by default.
+ * `zipFilenamePrefix`: `<String>` the prefix name to use for project zip files, or `"thimble-project"` by default.
+ * `capacity`: `<Number>` the number of bytes of disk space to allow for this project.  Defaults to 5MB if not set.
 
 ## Bramble.mount(root[, filename])
 
@@ -370,6 +371,9 @@ the following events:
 * `"projectSaved"` - triggered whenever the changes are saved to the filesystem in the browser are completed.
 * `"dialogOpened"` - triggered whenever a modal dialog opens, like when a user is deleting a file.
 * `"dialogClosed"` - triggered whenever a modal dialog closes.
+* `"capacityExceeded"` - triggered whenever the project's files reach or exceed the maximum allowed disk capacity. Some operations will be disallowed until sufficient space has been recovered (e.g., user deletes files).  A second argument, `size`, indicates the number of bytes the project is over capacity.
+* `"capacityRestored"` - triggered after a `"capacityExceeded"` event when sufficient space has been recovered to continue normal disk activity.
+* `"projectSizeChange"` - triggered when the project's size on disk changes. The event includes two arguments: `size`, which is the new size of the project in bytes, and `percentUsed` which is a percentage of disk space used out of the total available capacity.
 
 There are also high-level events for changes to files:
 

--- a/src/bramble/client/PathCache.js
+++ b/src/bramble/client/PathCache.js
@@ -1,0 +1,32 @@
+define(function() {
+    "use strict";
+
+    function PathCache() {
+        this.paths = {};
+    }
+    PathCache.prototype.add = function(path, size) {
+        this.paths[path] = size;
+    };
+    PathCache.prototype.remove = function(path) {
+        delete this.paths[path];
+    };
+    PathCache.prototype.rename = function(oldPath, newPath) {
+        this.paths[newPath] = this.paths[oldPath];
+        delete this.paths[oldPath];
+    };
+    PathCache.prototype.getTotalBytes = function() {
+        var paths = this.paths;
+
+        return Object.keys(paths).reduce(function(sum, path) {
+            return sum + paths[path];
+        }, 0);
+    };
+    PathCache.prototype.getFileCount = function() {
+        return Object.keys(this.paths).length;
+    };
+    PathCache.prototype.hasPath = function(path) {
+        return !!this.paths[path];
+    };
+
+    return PathCache;
+});

--- a/src/bramble/client/ProjectStats.js
+++ b/src/bramble/client/ProjectStats.js
@@ -1,131 +1,131 @@
 define([
-    // Change this to filer vs. filer.min if you need to debug Filer
     "thirdparty/filer/dist/filer.min",
-], function(Filer){
+    "EventEmitter",
+    "bramble/client/PathCache"
+], function(Filer, EventEmitter, PathCache) {
     "use strict";
 
-    var ProjectStats = {};
     var Path = Filer.Path;
-    var _root;
 
-    // keep track of project state
-    // host cache in the object should any other project states have to be added
-    var _cache = {};
+    function ProjectStats(options) {
+        this.root = options.root;
+        this.capacity = options.capacity;
+    }
+    ProjectStats.prototype = new EventEmitter();
+    ProjectStats.prototype.constructor = ProjectStats;
 
-    var _fs = new Filer.FileSystem();
-    var _shell = new _fs.Shell();
-    ProjectStats.getFileSystem = function(){
-        return _fs;
-    };
-    // NOTE: THIS WILL DESTROY DATA! For error cases only, or to wipe the disk.
-    ProjectStats.formatFileSystem = function(flags, callback){
-        _fs = new Filer.FileSystem(flags, callback);
-        _shell = new _fs.Shell();
-        return _fs;
-    };
+    // (Re)Initialize the ProjectStats instance with a new filesystem.
+    ProjectStats.prototype.init = function(fs, callback) {
+        var self = this;
 
-    // walk the whole file tree and record each path and file size
-    ProjectStats.init = function(root, callback){
-        function addSize(path, next){
+        self.cache = new PathCache();
+        self.overCapacity = false;
+
+        self.wrapFileSystem(fs);
+
+        function addSize(path, next) {
             // ignore directories and do nothing
             if (/\/$/.test(path)){
                 return next();
             }
 
-            _fs.stat(path, function(err, stats){
+            fs.stat(path, function(err, stats){
                 if (err){
                     return next(err);
                 }
-                _cache[path] = stats.size;
+
+                self.cache.add(path, stats.size);
+                self.checkCapacity();
+
                 next();
             });
         }
 
+        // walk the root
+        var shell = new fs.Shell();
+        shell.find(self.root, { exec:addSize }, callback);
+    };
+
+    ProjectStats.prototype.wrapFileSystem = function(fs) {
+        var self = this;
+        self.fs = fs;
+
         // original unlink
-        var _innerUnlink = _fs.unlink;
+        var _innerUnlink = fs.unlink;
         // overwrite unlink function to do the bookkeeping of project state and call original unlink.
-        _fs.unlink = function(pathname, callback){
-            _innerUnlink.call(_fs, pathname, function(err){
+        fs.unlink = function(pathname, callback){
+            _innerUnlink.call(fs, pathname, function(err){
                 // only update cache once original was successfull
                 if (!err){
-                    delete _cache[pathname];
+                    self.cache.remove(pathname);
+                    self.checkCapacity();
                 }
                 callback(err);
             });
         };
 
         // original writeFile
-        var _innerWriteFile = _fs.writeFile;
+        var _innerWriteFile = fs.writeFile;
         // overwrite original writeFile and add bookkeeping of project state and call original writeFile.
-        _fs.writeFile = function(filename, data, options, callback){
+        fs.writeFile = function(filename, data, options, callback){
             if (typeof options === "function"){
                 callback = options;
                 options = {};
             }
 
-            _innerWriteFile.call(_fs, filename, data, options, function(err){
+            _innerWriteFile.call(fs, filename, data, options, function(err){
                 // only update cache once original was successfull
                 if (!err){
-                    _cache[filename] = data.length;
+                    self.cache.add(filename, data.length);
+                    self.checkCapacity();
                 }
                 callback(err);
             });
         };
 
         // original rename
-        var _innerRename = _fs.rename;
+        var _innerRename = fs.rename;
         // overwrite original rename and add bookkeeping of project state and call original rename.
         // this is essential because we don't want to lose track of file's size for renamed files.
-        _fs.rename = function(oldPath, newPath, callback){
-            _innerRename.call(_fs, oldPath, newPath, function(err){
+        fs.rename = function(oldPath, newPath, callback){
+            _innerRename.call(fs, oldPath, newPath, function(err){
                 // only update cache once original was successfull
                 if (!err){
-                    _cache[newPath] = _cache[oldPath];
-                    delete _cache[oldPath];
+                    self.cache.rename(oldPath, newPath);
                 }
                 callback(err);
             });
         };
+    };
 
-        // returns true/false depending on whether root/index.html exists
-        ProjectStats.hasIndexFile = function(){
-            if (!_root){
-                return false;
-            }
+    // Monitor disk activity and trigger when we go over (or back under) capacity.
+    ProjectStats.prototype.checkCapacity = function() {
+        var size = this.getTotalProjectSize();
+        var diff = this.capacity - size;
+        var percentUsed = size / this.capacity;
 
-            var index = Path.join(_root, "index.html");
-            // Loop through all paths, return true if one of them is root/index.html
-            return !!(Object.keys(_cache)).find(function(path){
-                return path === index;
-            });
-        };
+        this.trigger("projectSizeChange", [size, percentUsed]);
 
-        // returns bytes of files in the root
-        ProjectStats.getTotalProjectSize = function(){
-            // Sum up all sizes in the cache and return
-            if (!_root){
-                return 0;
-            }
+        if (size >= this.capacity && !this.overCapacity) {
+            this.overCapacity = true;
+            this.trigger("capacityStateChange", [this.overCapacity, diff]);
+        } else if(size < this.capacity && this.overCapacity) {
+            this.overCapacity = false;
+            this.trigger("capacityStateChange", [this.overCapacity, diff]);
+        }
+    };
 
-            return (Object.values(_cache)).reduce(function(acc, val){
-                return acc + (val ? val : 0);
-            });
-        };
+    ProjectStats.prototype.getTotalProjectSize = function() {
+        return this.cache.getTotalBytes();
+    };
 
-        // returns project file count
-        ProjectStats.getFileCount = function(){
-            if (!_root){
-                return 0;
-            }
-            return Object.keys(_cache).length;
-        };
+    ProjectStats.prototype.getFileCount = function() {
+        return this.cache.getFileCount();
+    };
 
-        // reinitialize project stats
-        _root = root;
-        _cache = {};
-
-        // walk the root
-        _shell.find(_root, { exec:addSize }, callback);
+    ProjectStats.prototype.hasIndexFile = function() {
+        var index = Path.join(this.root, "index.html");
+        return this.cache.hasPath(index);
     };
 
     return ProjectStats;

--- a/src/bramble/client/main.js
+++ b/src/bramble/client/main.js
@@ -35,8 +35,9 @@ define([
     "bramble/ChannelUtils",
     "EventEmitter",
     "bramble/client/StateManager",
-    "bramble/client/ProjectStats"
-], function(Filer, ChannelUtils, EventEmitter, StateManager, ProjectStats) {
+    "bramble/client/ProjectStats",
+    "filesystem/impls/filer/lib/Sizes"
+], function(Filer, ChannelUtils, EventEmitter, StateManager, ProjectStats, Sizes) {
     "use strict";
 
     // PROD URL for Bramble, which can be changed below
@@ -54,6 +55,9 @@ define([
 
     // We only support having a single instance in the page.
     var _instance;
+
+    // Project size info, and filesystem book-keeping. We create during Bramble.mount()
+    var _projectStats;
 
     function parseEventData(data) {
         debug("parseEventData", data);
@@ -116,15 +120,25 @@ define([
 
     // Expose Filer for Path, Buffer, providers, etc.
     Bramble.Filer = Filer;
-    // We wrap the filesystem, and add metrics to keep track of project stats
-    var _fs = ProjectStats.getFileSystem();
+    var _fs = new Filer.FileSystem();
     Bramble.getFileSystem = function() {
         return _fs;
     };
-    
+
     // NOTE: THIS WILL DESTROY DATA! For error cases only, or to wipe the disk.
     Bramble.formatFileSystem = function(callback) {
-        _fs = ProjectStats.formatFileSystem({flags: ["FORMAT"]}, callback);
+        _fs = new Filer.FileSystem({flags: ["FORMAT"]}, function(err) {
+            if(err) {
+                return callback(err);
+            }
+
+            // Re-init the ProjectStats object with the updated filesystem instance.
+            if(_projectStats) {
+                _projectStats.init(_fs, callback);
+            } else {
+                callback();
+            }
+        });
     };
 
     // Start loading Bramble's resources, setup communication with iframe
@@ -155,14 +169,69 @@ define([
             return;
         }
 
-        ProjectStats.init(root, function(err){
+        _projectStats = new ProjectStats({
+            root: root,
+            capacity: _instance.getMaxCapacity(),
+        });
+
+        // Monitor disk use and limit activity when we hit capacity.
+        _projectStats.on("capacityStateChange", function(overCapacity, amountInBytes) {
+            function fireOverCapacity() {
+                console.warn("[Bramble] project has exceeded maximum allowed capacity by " + Math.abs(amountInBytes)+ " bytes. Limiting disk activity until space is recovered.");
+
+                _instance._executeRemoteCommand({
+                    commandCategory: "bramble",
+                    command: "ENABLE_PROJECT_CAPACITY_LIMITS"
+                });
+
+                _instance.trigger("capacityExceeded", [Math.abs(amountInBytes)]);
+            }
+
+            function fireCapacityRestored() {
+                console.warn("[Bramble] project within allowed capacity, removing disk actity limits.");
+
+                _instance._executeRemoteCommand({
+                    commandCategory: "bramble",
+                    command: "DISABLE_PROJECT_CAPACITY_LIMITS"
+                });
+
+                _instance.trigger("capacityRestored");
+            }
+
+            if(overCapacity) {
+                // If we're starting up, and exceed the size, wait til the app's fully loaded to trigger.
+                if(_readyState !== Bramble.READY) {
+                    Bramble.once("ready", fireOverCapacity);
+                } else {
+                    fireOverCapacity();
+                }
+            } else {
+                fireCapacityRestored();
+            }
+        });
+
+        _projectStats.init(_fs, function(err) {
             if(err) {
                 setReadyState(Bramble.ERROR, new Error("Unable to access filesystem: ", err));
                 return;
             }
+
+            // Listen for changes to the project's size on disk, and update both app + bramble with info.
+            _projectStats.on("projectSizeChange", function(size, percentUsed) {
+                _instance.trigger("projectSizeChange", [size, percentUsed]);
+
+                _instance._executeRemoteCommand({
+                    commandCategory: "bramble",
+                    command: "PROJECT_SIZE_CHANGE",
+                    args: [{
+                        size: size,
+                        percentUsed: percentUsed
+                    }]
+                });
+            });
+
             _instance.mount(root, filename);
         });
-
     };
 
     /**
@@ -208,6 +277,9 @@ define([
         // Whether or not we want to try and auto-recover a corrupted filesystem on error
         self._autoRecoverFileSystem = options.autoRecoverFileSystem;
 
+        // Project disk capacity.  If not specified, use default
+        var _capacity = options.capacity || Sizes.DEFAULT_PROJECT_SIZE_LIMIT;
+
         // Public getters for state. Most of these aren't useful until bramble.ready()
         self.getID = function() { return _id; };
         self.getIFrame = function() { return _iframe; };
@@ -227,9 +299,25 @@ define([
         self.getOpenSVGasXML = function() { return _state.openSVGasXML; };
         self.getTutorialExists = function() { return _tutorialExists; };
         self.getTutorialVisible = function() { return _tutorialVisible; };
-        self.getTotalProjectSize = function() { return ProjectStats.getTotalProjectSize(); };
-        self.hasIndexFile =  function() { return ProjectStats.hasIndexFile(); };
-        self.getFileCount = function() { return ProjectStats.getFileCount(); };
+        self.getTotalProjectSize = function() {
+            if(!_projectStats) {
+                return 0;
+            }
+            return _projectStats.getTotalProjectSize();
+        };
+        self.getMaxCapacity = function() { return _capacity; };
+        self.hasIndexFile =  function() {
+            if(!_projectStats) {
+                return false;
+            }
+            return _projectStats.hasIndexFile();
+        };
+        self.getFileCount = function() {
+           if(!_projectStats) {
+                return 0;
+            }
+            return _projectStats.getFileCount();
+        };
         self.getLayout = function() {
             return {
                 sidebarWidth: _state.sidebarWidth,

--- a/src/bramble/client/main.js
+++ b/src/bramble/client/main.js
@@ -93,6 +93,8 @@ define([
         // When we hit the READY state, also trigger an event and pass instance up
         if (_readyState === Bramble.READY) {
             Bramble.trigger("ready", [_instance]);
+            // Send project size info into Brackets too.
+            _projectStats.checkCapacity();
         }
         // When we go into the ERROR state, also trigger an event and pass err
         else if (_readyState === Bramble.ERROR) {
@@ -229,6 +231,7 @@ define([
                     }]
                 });
             });
+
 
             _instance.mount(root, filename);
         });

--- a/src/bramble/client/main.js
+++ b/src/bramble/client/main.js
@@ -179,14 +179,17 @@ define([
         // Monitor disk use and limit activity when we hit capacity.
         _projectStats.on("capacityStateChange", function(overCapacity, amountInBytes) {
             function fireOverCapacity() {
-                console.warn("[Bramble] project has exceeded maximum allowed capacity by " + Math.abs(amountInBytes)+ " bytes. Limiting disk activity until space is recovered.");
+                amountInBytes = Math.abs(amountInBytes);
+
+                console.warn("[Bramble] project has exceeded maximum allowed capacity by " + amountInBytes + " bytes. Limiting disk activity until space is recovered.");
 
                 _instance._executeRemoteCommand({
                     commandCategory: "bramble",
-                    command: "ENABLE_PROJECT_CAPACITY_LIMITS"
+                    command: "BRAMBLE_ENABLE_PROJECT_CAPACITY_LIMITS",
+                    args: [ amountInBytes ]
                 });
 
-                _instance.trigger("capacityExceeded", [Math.abs(amountInBytes)]);
+                _instance.trigger("capacityExceeded", [ amountInBytes ]);
             }
 
             function fireCapacityRestored() {
@@ -194,7 +197,7 @@ define([
 
                 _instance._executeRemoteCommand({
                     commandCategory: "bramble",
-                    command: "DISABLE_PROJECT_CAPACITY_LIMITS"
+                    command: "BRAMBLE_DISABLE_PROJECT_CAPACITY_LIMITS"
                 });
 
                 _instance.trigger("capacityRestored");
@@ -224,7 +227,7 @@ define([
 
                 _instance._executeRemoteCommand({
                     commandCategory: "bramble",
-                    command: "PROJECT_SIZE_CHANGE",
+                    command: "BRAMBLE_PROJECT_SIZE_CHANGE",
                     args: [{
                         size: size,
                         percentUsed: percentUsed

--- a/src/document/DocumentCommandHandlers.js
+++ b/src/document/DocumentCommandHandlers.js
@@ -63,6 +63,7 @@ define(function (require, exports, module) {
     var Content            = require("filesystem/impls/filer/lib/content");
     var saveAs             = require("thirdparty/FileSaver");
     var StartupState       = require("bramble/StartupState");
+    var Sizes              = require("filesystem/impls/filer/lib/Sizes");
     var Path               = BracketsFiler.Path;
     var fs                 = BracketsFiler.fs();
 
@@ -702,6 +703,11 @@ define(function (require, exports, module) {
      * Create a new file in the project tree.
      */
     function handleFileNewInProject() {
+        // XXXBramble: make sure we have enough room to add new files.
+        if(Sizes.getEnforceLimits()) {
+            return CommandManager.execute("bramble.projectSizeError");
+        }
+
         _handleNewItemInProject(false);
     }
 

--- a/src/extensions/default/UploadFiles/main.js
+++ b/src/extensions/default/UploadFiles/main.js
@@ -3,6 +3,7 @@ define(function (require, exports, module) {
 
     var CommandManager          = brackets.getModule("command/CommandManager");
     var ExtensionUtils          = brackets.getModule("utils/ExtensionUtils");
+    var Sizes                   = brackets.getModule("filesystem/impls/filer/lib/Sizes");
 
     var UploadFilesDialog       = require("UploadFilesDialog");
 
@@ -10,6 +11,10 @@ define(function (require, exports, module) {
     var CMD_UPLOAD_FILES_ID     = "bramble.showUploadFiles";
 
     function showUploadFiles() {
+        // Make sure we have enough room to add new files.
+        if(Sizes.getEnforceLimits()) {
+            return CommandManager.execute("bramble.projectSizeError");
+        }
         return UploadFilesDialog.show();
     }
 

--- a/src/extensions/default/bramble/lib/RemoteCommandHandler.js
+++ b/src/extensions/default/bramble/lib/RemoteCommandHandler.js
@@ -7,6 +7,7 @@ define(function (require, exports, module) {
     var CommandManager     = brackets.getModule("command/CommandManager");
     var EditorManager      = brackets.getModule("editor/EditorManager");
     var Commands           = brackets.getModule("command/Commands");
+    var FileSystem         = brackets.getModule("filesystem/FileSystem");
     var HTMLRewriter       = brackets.getModule("filesystem/impls/filer/lib/HTMLRewriter");
     var SidebarView        = brackets.getModule("project/SidebarView");
     var StatusBar          = brackets.getModule("widgets/StatusBar");
@@ -194,6 +195,17 @@ define(function (require, exports, module) {
         case "BRAMBLE_ADD_CODE_SNIPPET":
             skipCallback = true;
             CommandManager.execute("bramble.addCodeSnippet", args[0]).always(callback);
+            break;
+        case "ENABLE_PROJECT_CAPACITY_LIMITS":
+            FileSystem.setEnforceLimits(true);
+            UI.addProjectSizeWarning();
+            break;
+        case "DISABLE_PROJECT_CAPACITY_LIMITS":
+            FileSystem.setEnforceLimits(false);
+            UI.removeProjectSizeWarning();
+            break;
+        case "PROJECT_SIZE_CHANGE":
+            UI.setProjectSizeInfo(args[0]);
             break;
         default:
             console.log('[Bramble] unknown command:', command);

--- a/src/extensions/default/bramble/lib/UI.js
+++ b/src/extensions/default/bramble/lib/UI.js
@@ -12,6 +12,7 @@ define(function (require, exports, module) {
         BrambleEvents       = brackets.getModule("bramble/BrambleEvents"),
         BrambleStartupState = brackets.getModule("bramble/StartupState"),
         FileSystem          = brackets.getModule("filesystem/FileSystem"),
+        Sizes               = brackets.getModule("filesystem/impls/filer/lib/Sizes"),
         ViewCommandHandlers = brackets.getModule("view/ViewCommandHandlers"),
         SidebarView         = brackets.getModule("project/SidebarView"),
         WorkspaceManager    = brackets.getModule("view/WorkspaceManager"),
@@ -21,6 +22,8 @@ define(function (require, exports, module) {
     var PostMessageTransport = require("lib/PostMessageTransport");
 
     var isMobileViewOpen = false;
+
+    var DEFAULT_PROJECT_SIZE_LIMIT_FORMATTED = Sizes.formatBytes(Sizes.DEFAULT_PROJECT_SIZE_LIMIT);
 
     /**
      * This function calls all the hide functions and listens
@@ -282,6 +285,35 @@ define(function (require, exports, module) {
         return isMobileViewOpen ? "mobile" : "desktop";
     }
 
+    /**
+     * Update File Tree size info when the project's files changes on disk
+     */
+    function setProjectSizeInfo(info) {
+        var currentSize = Sizes.formatBytes(info.size);
+
+        // Normalize to between 0 - 100%
+        var percentUsed = (Math.max(Math.min(info.percentUsed * 100, 100), 0)).toFixed(2) + "%";
+
+        // TODO: update UI with progress bar and print X of Y strings to filetree.
+        console.log("setProjectSizeInfo", currentSize, DEFAULT_PROJECT_SIZE_LIMIT_FORMATTED, percentUsed);
+    }
+
+    /**
+     * When the project size on disk exceeds the allowed capacity, show a warning with info on what to do.
+     */
+    function addProjectSizeWarning() {
+        // TODO: update the file tree UI with some kind of warning and link to get info on what to do
+        console.log("addProjectSizeWarning");
+    }
+
+    /**
+     * When the project was previously over capacity, and now is within limits, remove the warning.
+     */
+    function removeProjectSizeWarning() {
+        // TODO: update the file tree UI to remove the size warning
+        console.log("removeProjectSizeWarning");
+    }
+
     // Define public API
     exports.initUI                 = initUI;
     exports.showMobileView         = showMobileView;
@@ -292,4 +324,7 @@ define(function (require, exports, module) {
     exports.removeLeftSideToolBar  = removeLeftSideToolBar;
     exports.removeMainToolBar      = removeMainToolBar;
     exports.removeRightSideToolBar = removeRightSideToolBar;
+    exports.setProjectSizeInfo     = setProjectSizeInfo;
+    exports.addProjectSizeWarning  = addProjectSizeWarning;
+    exports.removeProjectSizeWarning = removeProjectSizeWarning;
 });

--- a/src/extensions/default/bramble/lib/UI.js
+++ b/src/extensions/default/bramble/lib/UI.js
@@ -11,12 +11,17 @@ define(function (require, exports, module) {
         MainViewManager     = brackets.getModule("view/MainViewManager"),
         BrambleEvents       = brackets.getModule("bramble/BrambleEvents"),
         BrambleStartupState = brackets.getModule("bramble/StartupState"),
+        CommandManager      = brackets.getModule("command/CommandManager"),
         FileSystem          = brackets.getModule("filesystem/FileSystem"),
         Sizes               = brackets.getModule("filesystem/impls/filer/lib/Sizes"),
         ViewCommandHandlers = brackets.getModule("view/ViewCommandHandlers"),
         SidebarView         = brackets.getModule("project/SidebarView"),
         WorkspaceManager    = brackets.getModule("view/WorkspaceManager"),
-        PreferencesManager  = brackets.getModule("preferences/PreferencesManager");
+        PreferencesManager  = brackets.getModule("preferences/PreferencesManager"),
+        Dialogs             = brackets.getModule("widgets/Dialogs"),
+        DefaultDialogs      = brackets.getModule("widgets/DefaultDialogs"),
+        Strings             = brackets.getModule("strings"),
+        StringUtils         = brackets.getModule("utils/StringUtils");
 
     var PhonePreview  = require("text!lib/Mobile.html");
     var PostMessageTransport = require("lib/PostMessageTransport");
@@ -298,20 +303,17 @@ define(function (require, exports, module) {
     }
 
     /**
-     * When the project size on disk exceeds the allowed capacity, show a warning with info on what to do.
+     * Show the user an error dialog, indicating that the project has exceeded the max amount of disk space.
      */
-    function addProjectSizeWarning() {
-        // TODO: update the file tree UI with some kind of warning and link to get info on what to do
-        console.log("addProjectSizeWarning");
+    function showProjectSizeErrorDialog() {
+        return Dialogs.showModalDialog(
+            DefaultDialogs.DIALOG_ID_ERROR,
+            Strings.ERROR_OUT_OF_SPACE_TITLE,
+            Strings.ERROR_PROJECT_SIZE_EXCEEDED
+        ).getPromise();
     }
 
-    /**
-     * When the project was previously over capacity, and now is within limits, remove the warning.
-     */
-    function removeProjectSizeWarning() {
-        // TODO: update the file tree UI to remove the size warning
-        console.log("removeProjectSizeWarning");
-    }
+    CommandManager.registerInternal("bramble.projectSizeError", showProjectSizeErrorDialog);
 
     // Define public API
     exports.initUI                 = initUI;
@@ -324,6 +326,4 @@ define(function (require, exports, module) {
     exports.removeMainToolBar      = removeMainToolBar;
     exports.removeRightSideToolBar = removeRightSideToolBar;
     exports.setProjectSizeInfo     = setProjectSizeInfo;
-    exports.addProjectSizeWarning  = addProjectSizeWarning;
-    exports.removeProjectSizeWarning = removeProjectSizeWarning;
 });

--- a/src/extensions/default/bramble/lib/UI.js
+++ b/src/extensions/default/bramble/lib/UI.js
@@ -294,8 +294,7 @@ define(function (require, exports, module) {
         // Normalize to between 0 - 100%
         var percentUsed = (Math.max(Math.min(info.percentUsed * 100, 100), 0)).toFixed(2) + "%";
 
-        // TODO: update UI with progress bar and print X of Y strings to filetree.
-        console.log("setProjectSizeInfo", currentSize, DEFAULT_PROJECT_SIZE_LIMIT_FORMATTED, percentUsed);
+        SidebarView._updateProjectSizeIndicator(currentSize, DEFAULT_PROJECT_SIZE_LIMIT_FORMATTED, percentUsed);
     }
 
     /**

--- a/src/extensions/default/bramble/stylesheets/sidebarTheme.less
+++ b/src/extensions/default/bramble/stylesheets/sidebarTheme.less
@@ -31,11 +31,18 @@ div.working-set-option-btn[style] {
     padding: 12px 0 0 0;
     font-weight: 400;
     font-family: "Open Sans", "Helvetica Neue", sans-serif;
+    overflow-x: hidden !important;
 }
 
 // Indicates used and available room in a project
 #project-size-info {
     padding: 12px 10px;
+    transition: opacity .2s ease-out;
+    overflow: hidden;
+
+    &.hidden {
+        opacity: 0;
+    }
 
     .space-available {
         background: rgba(0,0,0,.1);
@@ -48,17 +55,29 @@ div.working-set-option-btn[style] {
     .space-used-bar {
         border-radius: 2px;
         width: 0;
-        background: rgba(27,134,78,.7);
+        background: #61a782;
         height: 100%;
         position: absolute;
         left: 0;
-        transition: width .2s ease-out;
-        transition-delay: .5s;
+        transition: all .2s ease-out;
+        transition-delay: .2s;
     }
 
-    &.project-size-warning {
+    &.project-size-warning .space-used-bar {
+        background: #ef7e42;
+    }
+
+    &.project-size-exceeded {
         .space-used-bar {
-            background: rgba(197, 69, 14, .7);
+            background: #da2828;
+        }
+
+        .space-used-summary {
+            color: #da2828;
+
+            strong {
+                color: inherit;
+            }
         }
     }
 
@@ -82,13 +101,7 @@ div.working-set-option-btn[style] {
     }
 
     .space-used-bar {
-        background: rgba(27,134,78,.7);
-    }
-
-    &.project-size-warning {
-        .space-used-bar {
-            background: rgba(197, 69, 14, .7);
-        }
+        background: #2a794f;
     }
 
     .space-used-summary {
@@ -98,12 +111,30 @@ div.working-set-option-btn[style] {
             color: rgba(255,255,255,.5);
         }
     }
+
+    &.project-size-warning .space-used-bar {
+        background: #c35921;
+    }
+
+    &.project-size-exceeded {
+
+        .space-used-bar {
+            background: #a51818;
+        }
+
+        .space-used-summary {
+            color: #a02626;
+
+            strong {
+                color: inherit;
+            }
+        }
+    }
 }
 
 #project-files-container ul {
     padding: 0 !important;
 }
-
 
 /* File tree basic styles */
 

--- a/src/extensions/default/bramble/stylesheets/sidebarTheme.less
+++ b/src/extensions/default/bramble/stylesheets/sidebarTheme.less
@@ -33,6 +33,7 @@ div.working-set-option-btn[style] {
     font-family: "Open Sans", "Helvetica Neue", sans-serif;
 }
 
+// Indicates used and available room in a project
 #project-size-info {
     padding: 12px 10px;
     background: rgba(0,0,0,.9);
@@ -47,11 +48,19 @@ div.working-set-option-btn[style] {
 
     .space-used-bar {
         border-radius: 2px;
-        width: 60%;
+        width: 0;
         background: rgba(27,134,78,.7);
         height: 100%;
         position: absolute;
         left: 0;
+        transition: width .2s ease-out;
+        transition-delay: .5s;
+    }
+
+    &.project-size-warning {
+        .space-used-bar {
+            background: rgba(197, 69, 14, .7);
+        }
     }
 
     .space-used-summary {

--- a/src/extensions/default/bramble/stylesheets/sidebarTheme.less
+++ b/src/extensions/default/bramble/stylesheets/sidebarTheme.less
@@ -36,10 +36,9 @@ div.working-set-option-btn[style] {
 // Indicates used and available room in a project
 #project-size-info {
     padding: 12px 10px;
-    background: rgba(0,0,0,.9);
 
     .space-available {
-        background: rgba(255,255,255,.2);
+        background: rgba(0,0,0,.1);
         position: relative;
         height: 6px;
         margin-bottom: 6px;
@@ -64,13 +63,38 @@ div.working-set-option-btn[style] {
     }
 
     .space-used-summary {
-        color: rgba(255,255,255,.4);
+        color: rgba(0,0,0,.4);
         font-family: "Open Sans";
         margin: 0;
 
         strong {
             font-weight: 600;
             color: inherit;
+            color: rgba(0,0,0,.5);
+        }
+    }
+}
+
+.dark #project-size-info {
+
+    .space-available {
+        background: rgba(255,255,255,.2);
+    }
+
+    .space-used-bar {
+        background: rgba(27,134,78,.7);
+    }
+
+    &.project-size-warning {
+        .space-used-bar {
+            background: rgba(197, 69, 14, .7);
+        }
+    }
+
+    .space-used-summary {
+        color: rgba(255,255,255,.4);
+
+        strong {
             color: rgba(255,255,255,.5);
         }
     }

--- a/src/extensions/default/bramble/stylesheets/sidebarTheme.less
+++ b/src/extensions/default/bramble/stylesheets/sidebarTheme.less
@@ -33,6 +33,40 @@ div.working-set-option-btn[style] {
     font-family: "Open Sans", "Helvetica Neue", sans-serif;
 }
 
+#project-size-info {
+    padding: 12px 10px;
+    background: rgba(0,0,0,.9);
+
+    .space-available {
+        background: rgba(255,255,255,.2);
+        position: relative;
+        height: 6px;
+        margin-bottom: 6px;
+        border-radius: 2px;
+    }
+
+    .space-used-bar {
+        border-radius: 2px;
+        width: 60%;
+        background: rgba(27,134,78,.7);
+        height: 100%;
+        position: absolute;
+        left: 0;
+    }
+
+    .space-used-summary {
+        color: rgba(255,255,255,.4);
+        font-family: "Open Sans";
+        margin: 0;
+
+        strong {
+            font-weight: 600;
+            color: inherit;
+            color: rgba(255,255,255,.5);
+        }
+    }
+}
+
 #project-files-container ul {
     padding: 0 !important;
 }

--- a/src/filesystem/FileSystem.js
+++ b/src/filesystem/FileSystem.js
@@ -1032,16 +1032,6 @@ define(function (require, exports, module) {
     // Export the FileSystem class as "private" for unit testing only.
     exports._FileSystem = FileSystem;
 
-    // XXXBramble: we track whether or not to do certain filesystem operations based
-    // on how large a project is vs. the requested disk capacity.
-    var _enforceLimits = false;
-    exports.getEnforceLimits = function() {
-        return _enforceLimits;
-    };
-    exports.setEnforceLimits = function(value) {
-        _enforceLimits = value;
-    };
-
     // Create the singleton instance
     _instance = new FileSystem();
 

--- a/src/filesystem/FileSystem.js
+++ b/src/filesystem/FileSystem.js
@@ -1032,6 +1032,16 @@ define(function (require, exports, module) {
     // Export the FileSystem class as "private" for unit testing only.
     exports._FileSystem = FileSystem;
 
+    // XXXBramble: we track whether or not to do certain filesystem operations based
+    // on how large a project is vs. the requested disk capacity.
+    var _enforceLimits = false;
+    exports.getEnforceLimits = function() {
+        return _enforceLimits;
+    };
+    exports.setEnforceLimits = function(value) {
+        _enforceLimits = value;
+    };
+
     // Create the singleton instance
     _instance = new FileSystem();
 

--- a/src/filesystem/impls/filer/lib/Sizes.js
+++ b/src/filesystem/impls/filer/lib/Sizes.js
@@ -61,4 +61,16 @@ define(function (require, exports, module) {
     exports.RESIZED_IMAGE_TARGET_SIZE_KB = RESIZED_IMAGE_TARGET_SIZE_KB;
     exports.IMAGE_RESIZE_TOLERANCE_KB = IMAGE_RESIZE_TOLERANCE_KB;
     exports.formatBytes = formatBytes;
+
+    // We track whether or not to do certain filesystem operations based
+    // on how large a project is vs. the requested disk capacity.
+    var _enforceLimits = false;
+
+    exports.getEnforceLimits = function() {
+        return _enforceLimits;
+    };
+
+    exports.setEnforceLimits = function(value) {
+        _enforceLimits = value;
+    };
 });

--- a/src/filesystem/impls/filer/lib/Sizes.js
+++ b/src/filesystem/impls/filer/lib/Sizes.js
@@ -5,8 +5,13 @@
 define(function (require, exports, module) {
     "use strict";
 
+    var UNITS = ['B', 'kB', 'MB'];
+
     var KB = 1024;
     var MB = 1024 * KB;
+
+    // 5MB default size limit for total project size on disk
+    var DEFAULT_PROJECT_SIZE_LIMIT = 5 * MB;
 
     // 3MB size limit for imported files.
     var REGULAR_FILE_SIZE_LIMIT_MB = 3 * MB;
@@ -23,11 +28,37 @@ define(function (require, exports, module) {
     // 20KB +/- of error tolerance when we auto-resize images
     var IMAGE_RESIZE_TOLERANCE_KB = 20 * KB;
 
+    // Pretty print a size in bytes in KB or MB.
+    // Based on https://github.com/sindresorhus/pretty-bytes/blob/master/index.js (MIT)
+    function formatBytes(num) {
+        if(!Number.isFinite(num)) {
+            return "?";
+        }
+
+        var neg = num < 0;
+
+        if(neg) {
+            num = -num;
+        }
+
+        if(num < 1) {
+            return (neg ? '-' : '') + num + ' B';
+        }
+
+        var exponent = Math.min(Math.floor(Math.log10(num) / 3), UNITS.length - 1);
+        var numStr = Number((num / Math.pow(1000, exponent)).toPrecision(3));
+        var unit = UNITS[exponent];
+
+        return (neg ? '-' : '') + numStr + ' ' + unit;
+    }
+
     exports.KB = KB;
     exports.MB = MB;
+    exports.DEFAULT_PROJECT_SIZE_LIMIT = DEFAULT_PROJECT_SIZE_LIMIT;
     exports.REGULAR_FILE_SIZE_LIMIT_MB = REGULAR_FILE_SIZE_LIMIT_MB;
     exports.ARCHIVE_FILE_LIMIT_MB = ARCHIVE_FILE_LIMIT_MB;
     exports.RESIZABLE_IMAGE_FILE_LIMIT_MB = RESIZABLE_IMAGE_FILE_LIMIT_MB;
     exports.RESIZED_IMAGE_TARGET_SIZE_KB = RESIZED_IMAGE_TARGET_SIZE_KB;
     exports.IMAGE_RESIZE_TOLERANCE_KB = IMAGE_RESIZE_TOLERANCE_KB;
+    exports.formatBytes = formatBytes;
 });

--- a/src/filesystem/impls/filer/lib/Sizes.js
+++ b/src/filesystem/impls/filer/lib/Sizes.js
@@ -7,8 +7,8 @@ define(function (require, exports, module) {
 
     var UNITS = ['B', 'kB', 'MB'];
 
-    var KB = 1024;
-    var MB = 1024 * KB;
+    var KB = 1000;
+    var MB = 1000 * KB;
 
     // 5MB default size limit for total project size on disk
     var DEFAULT_PROJECT_SIZE_LIMIT = 5 * MB;

--- a/src/hosted.js
+++ b/src/hosted.js
@@ -103,6 +103,14 @@
             console.log("Bramble ready");
             // For debugging, attach to window.
             window.bramble = bramble;
+
+            bramble.on("capacityExceeded", function(amountInBytes) {
+                console.log("[Bramble] capacityExceeded event", amountInBytes);
+            });
+
+            bramble.on("capacityRestored", function() {
+                console.log("[Bramble] capacityRestored event.");
+            });
         });
 
         Bramble.once("error", function(err) {

--- a/src/htmlContent/main-view.html
+++ b/src/htmlContent/main-view.html
@@ -53,7 +53,7 @@
             <div id="project-files-container">
                 <!-- This will contain a dynamically generated <ul> hierarchy at runtime -->
             </div>
-            <div id="project-size-info" class="hidden">
+            <div id="project-size-info">
                 <div class="space-available">
                     <div class="space-used-bar"></div>
                 </div>

--- a/src/htmlContent/main-view.html
+++ b/src/htmlContent/main-view.html
@@ -53,11 +53,14 @@
             <div id="project-files-container">
                 <!-- This will contain a dynamically generated <ul> hierarchy at runtime -->
             </div>
-            <div id="project-size-info">
+            <div id="project-size-info" class="hidden">
                 <div class="space-available">
                     <div class="space-used-bar"></div>
                 </div>
-                <p class="space-used-summary"><strong class="space-used">1.2</strong> of <strong>3 MB</strong> used</p>
+                <p class="space-used-summary">
+                    <strong class="space-used"></strong> of
+                    <strong class="max-project-size"></strong> used
+                </p>
             </div>
         </div>
 

--- a/src/htmlContent/main-view.html
+++ b/src/htmlContent/main-view.html
@@ -1,22 +1,22 @@
-<!-- 
+<!--
   Copyright (c) 2012 - present Adobe Systems Incorporated. All rights reserved.
-   
+
   Permission is hereby granted, free of charge, to any person obtaining a
-  copy of this software and associated documentation files (the "Software"), 
-  to deal in the Software without restriction, including without limitation 
-  the rights to use, copy, modify, merge, publish, distribute, sublicense, 
-  and/or sell copies of the Software, and to permit persons to whom the 
+  copy of this software and associated documentation files (the "Software"),
+  to deal in the Software without restriction, including without limitation
+  the rights to use, copy, modify, merge, publish, distribute, sublicense,
+  and/or sell copies of the Software, and to permit persons to whom the
   Software is furnished to do so, subject to the following conditions:
-   
+
   The above copyright notice and this permission notice shall be included in
   all copies or substantial portions of the Software.
-   
+
   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
-  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
-  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
   DEALINGS IN THE SOFTWARE.
 -->
 
@@ -27,13 +27,13 @@
 
     LOCALIZATION NOTE:
     All display text for this file must use templating so the text can be localized.
-    
+
     English text goes in src/nls/root/strings.js. All other translations go in the strings.js file for
     the specific local in the nls folder. If a translation is missing for a specific key English
     is used as a fallback
 
     Strings should be referenced using the double brackets syntax.
-    Example: {{keyname}}. Note, all strings are HTML escaped unless the form 
+    Example: {{keyname}}. Note, all strings are HTML escaped unless the form
     {{&keyname}} is used.
 
 -->
@@ -43,9 +43,9 @@
         <div id="sidebar" class="sidebar panel quiet-scrollbars horz-resizable right-resizer collapsible" data-minsize="0" data-maxsize="80%" data-forceleft=".content">
             <div class="working-set-splitview-btn btn-alt-quiet"></div>
             <div class="working-set-option-btn btn-alt-quiet"></div>
-            
+
             <div id="working-set-list-container">
-                
+
             </div>
             <div id="project-files-header">
                 <span id="project-title" class="title"></span>
@@ -53,8 +53,14 @@
             <div id="project-files-container">
                 <!-- This will contain a dynamically generated <ul> hierarchy at runtime -->
             </div>
+            <div id="project-size-info">
+                <div class="space-available">
+                    <div class="space-used-bar"></div>
+                </div>
+                <p class="space-used-summary"><strong class="space-used">1.2</strong> of <strong>3 MB</strong> used</p>
+            </div>
         </div>
-        
+
         <!--
             Vertical stack of titlebar (in-browser), editor, bottom panels, status bar
                 (status bar is injected later - see StatusBar.init()).
@@ -69,19 +75,19 @@
                 <!-- Menu bar -->
                 <ul class="nav" data-dropdown="dropdown">
                 </ul>
-                
+
                 <!-- Filename label -->
                 <div class="title-wrapper">
                     <span class="title"></span>&nbsp;<span class='dirty-dot' style="visibility:hidden;">•</span>
                 </div>
             </div>
-            
+
             <div id="editor-holder" {{#shouldAddAA}}class="subpixel-aa"{{/shouldAddAA}}>
                 <!-- View Panes are programatically created here -->
             </div>
-            
+
             <!-- Bottom panels and status bar are programmatically created here -->
-            
+
         </div>
 
         <!-- Vertical toolbar docked to right -->
@@ -94,7 +100,7 @@
             </div>
             <div class="bottom-buttons"></div>
         </div>
-        
+
         <!-- Hack to ensure that the code editor's web font is loaded early. -->
         <!-- For more info, see note in brackets.less for class .dummy-text, or issue 76 -->
         <div class="dummy-text">x</div>

--- a/src/project/SidebarView.js
+++ b/src/project/SidebarView.js
@@ -149,11 +149,15 @@ define(function (require, exports, module) {
     }
 
     // Updates the project size indicator UI
-    function _updateProjectSizeIndicator() {
-        var percent = Math.random() * 100;
-        console.log(Math.round(percent));
-        $projectSizeIndicator.find(".space-used-bar").css("width", percent + "%");
-        $projectSizeIndicator.find(".space-used").text((percent/100 * 3).toFixed(2));
+    function _updateProjectSizeIndicator(currentSize, maxSize, percent) {
+        if(parseInt(percent) > 80) {
+            $projectSizeIndicator.addClass("project-size-warning");
+        } else {
+            $projectSizeIndicator.removeClass("project-size-warning");
+        }
+        $projectSizeIndicator.find(".space-used-bar").css("width", percent);
+        $projectSizeIndicator.find(".space-used").text(currentSize);
+        $projectSizeIndicator.find(".max-project-size").text(maxSize);
     }
 
     /**
@@ -301,4 +305,5 @@ define(function (require, exports, module) {
     exports.hide        = hide;
     exports.isVisible   = isVisible;
     exports.resize      = resize;
+    exports._updateProjectSizeIndicator = _updateProjectSizeIndicator;
 });

--- a/src/project/SidebarView.js
+++ b/src/project/SidebarView.js
@@ -53,7 +53,8 @@ define(function (require, exports, module) {
         $splitViewMenu,
         $projectTitle,
         $projectFilesContainer,
-        $workingSetViewsContainer;
+        $workingSetViewsContainer,
+        $projectSizeIndicator;
     var _cmdSplitNone,
         _cmdSplitVertical,
         _cmdSplitHorizontal;
@@ -147,6 +148,14 @@ define(function (require, exports, module) {
         }
     }
 
+    // Updates the project size indicator UI
+    function _updateProjectSizeIndicator() {
+        var percent = Math.random() * 100;
+        console.log(Math.round(percent));
+        $projectSizeIndicator.find(".space-used-bar").css("width", percent + "%");
+        $projectSizeIndicator.find(".space-used").text((percent/100 * 3).toFixed(2));
+    }
+
     /**
      * Update state of splitview and option elements
      * @private
@@ -209,6 +218,7 @@ define(function (require, exports, module) {
         $projectTitle             = $sidebar.find("#project-title");
         $projectFilesContainer    = $sidebar.find("#project-files-container");
         $workingSetViewsContainer = $sidebar.find("#working-set-list-container");
+        $projectSizeIndicator     = $sidebar.find("#project-size-info");
 
         // init
         $sidebar.on("panelResizeStart", function (evt, width) {
@@ -265,6 +275,7 @@ define(function (require, exports, module) {
         });
 
         _updateUIStates();
+        _updateProjectSizeIndicator();
 
         // Tooltips
         $gearMenu.attr("title", Strings.GEAR_MENU_TOOLTIP);

--- a/src/project/SidebarView.js
+++ b/src/project/SidebarView.js
@@ -150,12 +150,23 @@ define(function (require, exports, module) {
 
     // Updates the project size indicator UI
     function _updateProjectSizeIndicator(currentSize, maxSize, percent) {
-        if(parseInt(percent) > 80) {
-            $projectSizeIndicator.addClass("project-size-warning");
+        $projectSizeIndicator.removeClass("project-size-warning project-size-exceeded");
+
+        percent = parseInt(percent);
+        if(percent < 10) {
+            $projectSizeIndicator.addClass("hidden");
+            return;
         } else {
-            $projectSizeIndicator.removeClass("project-size-warning");
+            $projectSizeIndicator.removeClass("hidden");
         }
-        $projectSizeIndicator.find(".space-used-bar").css("width", percent);
+
+        if(percent > 80 && percent < 100) {
+            $projectSizeIndicator.addClass("project-size-warning");
+        } else if(percent === 100) {
+            $projectSizeIndicator.addClass("project-size-exceeded");
+        }
+
+        $projectSizeIndicator.find(".space-used-bar").css("width", percent + "%");
         $projectSizeIndicator.find(".space-used").text(currentSize);
         $projectSizeIndicator.find(".max-project-size").text(maxSize);
     }

--- a/src/project/SidebarView.js
+++ b/src/project/SidebarView.js
@@ -156,9 +156,9 @@ define(function (require, exports, module) {
         if(percent < 10) {
             $projectSizeIndicator.addClass("hidden");
             return;
-        } else {
-            $projectSizeIndicator.removeClass("hidden");
         }
+
+        $projectSizeIndicator.removeClass("hidden");
 
         if(percent > 80 && percent < 100) {
             $projectSizeIndicator.addClass("project-size-warning");

--- a/src/utils/Compatibility.js
+++ b/src/utils/Compatibility.js
@@ -35,6 +35,11 @@ define(function (require, exports, module) {
         String.prototype.trimLeft = function () { return this.replace(/^\s+/, ""); };
     }
 
+    // [IE] Number.isFinite() is missing
+    Number.isFinite = Number.isFinite || function(value) {
+        return typeof value === 'number' && isFinite(value);
+    };
+
     // Feature detection for Error.stack. Not all browsers expose it
     // and Brackets assumes it will be a non-null string.
     if (typeof (new Error()).stack === "undefined") {

--- a/src/utils/DragAndDrop.js
+++ b/src/utils/DragAndDrop.js
@@ -41,7 +41,8 @@ define(function (require, exports, module) {
         StringUtils     = require("utils/StringUtils"),
         // XXXBramble specific bits
         FileImport      = require("filesystem/impls/filer/lib/FileImport"),
-        FileSystemCache = require("filesystem/impls/filer/FileSystemCache");
+        FileSystemCache = require("filesystem/impls/filer/FileSystemCache"),
+        Sizes           = require("filesystem/impls/filer/lib/Sizes");
 
     // If the user indicates they want to import files deep into the filetree
     // this is the path they want to use as a parent dir root.
@@ -322,6 +323,15 @@ define(function (require, exports, module) {
      * and process them, such that they end
      */
     function processFiles(source, callback) {
+        // Make sure we have enough room to add new files.
+        if(Sizes.getEnforceLimits()) {
+            return CommandManager
+                .execute("bramble.projectSizeError")
+                .done(function() {
+                    callback(new Error("not enough free space."));
+                });
+        }
+
         FileImport.import(source, _dropPathHint, function(err, paths) {
             // Reset drop path, until we get an explicit one set in future.
             _dropPathHint = null;


### PR DESCRIPTION
This is part of a fix for https://github.com/mozilla/thimble.mozilla.org/issues/2296.  It adds a number of new events to Bramble, and also wires up an internal system for tracking and enforcing limits on the filesystem.  I have not yet done any enforcement.

When there is activity on disk, we check to see what has happened to the total project size vs. the project's capacity, as set when the filesystem loads (default is 5MB).  We raise a `projectSizeChange` event that can be used in Thimble to display info about the current project disk usage.  When the file size goes over the capacity, we fire an event, `capacityExceeded`, and later a `capacityRestored` event if the space is recovered.  Between these events we set a flag on the `FileSystem` module that we can use in other parts of the code to block certain actions (e.g., file import, selfies, etc).  Probably that needs to happen in another patch.