### PR TITLE
Fixed color bug in the dialog

### DIFF
--- a/src/styles/bramble_overrides.less
+++ b/src/styles/bramble_overrides.less
@@ -380,6 +380,10 @@ span.dialog-button {
     margin: 0;
   }
 
+  li {
+    color: black;
+  }
+
   .modal-footer {
     background: rgba(0,0,0,.1);
     border-radius: 0;


### PR DESCRIPTION
Fixes a bug where ``<li>`` elements within the popup dialog had white text color when the editor was in the dark theme, making them invisible.

To test, drag an unsupported filetype (like ``test.map``) into the file view with the editor in the dark theme and you should see the following... 

![image](https://user-images.githubusercontent.com/25212/27344587-b1980900-559b-11e7-99f8-4dbfc24b92b5.png)

Previously the bulleted item was invisible.

Fixes https://github.com/mozilla/thimble.mozilla.org/issues/2271
