### PR TITLE
Fixed wrong color when file is right-clicked in dark theme.

### DIFF
--- a/src/extensions/default/bramble/stylesheets/sidebarTheme.less
+++ b/src/extensions/default/bramble/stylesheets/sidebarTheme.less
@@ -199,9 +199,12 @@ li.jstree-leaf a.context-node span {
 
 /* Currently selected (edited) file */
 
-li.jstree-leaf a.selected-node,
-li.jstree-leaf a.selected-node:hover {
-    background: #222;
+li.jstree-leaf a.selected-node {
+  background: #222;
+
+  span {
+    color: white;
+  }
 }
 
 body[data-theme='light-theme'] li.jstree-leaf a.selected-node,


### PR DESCRIPTION
Selected, and right-clicked files now have the correct text color as seen here (white)...

![image](https://user-images.githubusercontent.com/25212/27399520-e34a076a-5671-11e7-9735-88f73d0e555c.png)

Whereas before you can see that the "index" part of the filename is darker...

![image](https://user-images.githubusercontent.com/25212/27399529-ee7b4e82-5671-11e7-8dc2-dcda5243e7b2.png)

Fixes https://github.com/mozilla/thimble.mozilla.org/issues/2318

