### PR TITLE
Only showing Image Viewer swatches if we have a color.

### DIFF
--- a/src/editor/ImageViewer.js
+++ b/src/editor/ImageViewer.js
@@ -59,26 +59,27 @@ define(function (require, exports, module) {
         var swatches;
         var i = 0;
 
+        // Hide all the swatch elements, we'll unhide them later one by one as needed
+        $(".image-view-swatches .swatch-wrapper").addClass("hide");
+
         try {
             var vibrant = new window.Vibrant(img);
             swatches = vibrant.swatches();
-            $(".image-view-swatches").removeClass("hide");
         } catch(e) {
-            // Hide the color swatches, since we can't display anything
-            $(".image-view-swatches").addClass("hide");
             return;
         }
 
         Object.keys(swatches).forEach(function(swatch) {
             var swatchColor = swatchElems[i];
             var swatchHex = hexElems[i];
-
             var hex = swatches[swatch] && swatches[swatch].getHex();
+
             // Sometimes there isn't a LightMuted color
             if(!hex) {
                 return;
             }
 
+            swatchHex.parentNode.classList.remove("hide");
             swatchColor.style.backgroundColor = hex;
             swatchHex.textContent = hex;
             i++;


### PR DESCRIPTION
Currently we show all of the swatch holder DOM elements even when we don't display the swatches, adding extra blank space. This patch only shows the DOM elements if we need them. So an image with just a few swatches will display as...

<img src="https://user-images.githubusercontent.com/25212/27411198-0699aeda-56a1-11e7-8272-15cdbbf75936.png" width="250" />

Note the lack of empty space between the swatches and image.

Fixes https://github.com/mozilla/thimble.mozilla.org/issues/2304
