### PR TITLE
Harmonize fs readFile and writeFile to work a proper level of abstraction

### DIFF
--- a/src/extensions/default/BrambleUrlCodeHints/camera/index.js
+++ b/src/extensions/default/BrambleUrlCodeHints/camera/index.js
@@ -8,7 +8,7 @@ define(function (require, exports, module) {
 
     var CommandManager = brackets.getModule("command/CommandManager");
     var Commands       = brackets.getModule("command/Commands");
-    var fs             = brackets.getModule("fileSystemImpl");
+    var FilerUtils     = brackets.getModule("filesystem/impls/filer/FilerUtils");
 
     var Interface = require("camera/interface");
     var Video = require("camera/video");
@@ -46,16 +46,15 @@ define(function (require, exports, module) {
     Camera.prototype.savePhoto = function(data) {
         var self = this;
 
-        fs.writeFile(this.savePath, data, {encoding: null}, function(err) {
-            if(err) {
-                return self.fail(err);
-            }
+        FilerUtils
+            .writeFileAsBinary(this.savePath, data)
+            .done(function() {
+                // Update the file tree to show the new file
+                CommandManager.execute(Commands.FILE_REFRESH);
 
-            // Update the file tree to show the new file
-            CommandManager.execute(Commands.FILE_REFRESH);
-
-            self.success(self.savePath);
-        });
+                self.success(self.savePath);
+            })
+            .fail(self.fail);
     };
 
     // End the camera session if everything goes well

--- a/src/extensions/default/bramble/lib/XHRManager.js
+++ b/src/extensions/default/bramble/lib/XHRManager.js
@@ -2,8 +2,8 @@ define(function (require, exports, module) {
     "use strict";
 
     var UrlCache         = brackets.getModule("filesystem/impls/filer/UrlCache");
-    var Path             = brackets.getModule("filesystem/impls/filer/BracketsFiler").Path;
-    var fs               = brackets.getModule("filesystem/impls/filer/BracketsFiler").fs();
+    var FilerUtils       = brackets.getModule("filesystem/impls/filer/FilerUtils");
+    var Path             = FilerUtils.Path;
     var Browser          = require("lib/iframe-browser");
     var transport        = require("lib/PostMessageTransport");
 
@@ -33,7 +33,7 @@ define(function (require, exports, module) {
         var response = {method: "XMLHttpRequest"};
 
         // For now, we support text based requests only
-        fs.readFile(path, "utf8", function(err, data) {
+        FilerUtils.readFileAsUTF8(path, function(err, data) {
             if(err) {
                 if(err.code === "ENOENT") {
                     response.error = "No resource found for `" + path + "`";

--- a/src/filesystem/impls/filer/BracketsFiler.js
+++ b/src/filesystem/impls/filer/BracketsFiler.js
@@ -3,6 +3,16 @@
 define(function (require, exports, module) {
     "use strict";
 
+    /**
+     * NOTE: For reading and writing UTF8 and Binary files, it is best/easiest
+     * to use the filesystem/impls/filer/FilerUtils module, since it does
+     * things at the right level of abstraction:
+     *  - readFileAsUTF8()
+     *  - readFileAsBinary()
+     *  - writeFileAsUTF8()
+     *  - writeFileASBinary()
+     */
+
     var proxyCall = require("filesystem/impls/filer/RemoteFiler").proxyCall;
     var FilerUtils = require("filesystem/impls/filer/FilerUtils");
     var Path = FilerUtils.Path;

--- a/src/filesystem/impls/filer/FilerFileSystem.js
+++ b/src/filesystem/impls/filer/FilerFileSystem.js
@@ -4,6 +4,16 @@
 define(function (require, exports, module) {
     "use strict";
 
+    /**
+     * NOTE: For reading and writing UTF8 and Binary files, it is best/easiest
+     * to use the filesystem/impls/filer/FilerUtils module, since it does
+     * things at the right level of abstraction:
+     *  - readFileAsUTF8()
+     *  - readFileAsBinary()
+     *  - writeFileAsUTF8()
+     *  - writeFileASBinary()
+     */
+
     var FileSystemError = require("filesystem/FileSystemError"),
         FileSystemStats = require("filesystem/FileSystemStats"),
         BracketsFiler   = require("filesystem/impls/filer/BracketsFiler"),

--- a/src/filesystem/impls/filer/FilerUtils.js
+++ b/src/filesystem/impls/filer/FilerUtils.js
@@ -4,6 +4,8 @@
 define(function (require, exports, module) {
     "use strict";
 
+    var Async           = require("utils/Async");
+    var FileSystem      = require("filesystem/FileSystem");
     var Buffer          = require("thirdparty/filer/dist/buffer.min");
 
     // Based on http://stackoverflow.com/questions/21797299/convert-base64-string-to-arraybuffer
@@ -45,5 +47,75 @@ define(function (require, exports, module) {
     exports.normalizeExtension = function(ext, excludePeriod) {
         var maybePeriod = excludePeriod ? "" : ".";
         return maybePeriod + ext.replace(/^\./, "").toLowerCase();
+    };
+
+    /**
+     * Helper functions for reading and writing files.  Prefer these to fs.readFile/writeFile
+     * since it will also trigger a number of higher-level abstractions in Brackets, including
+     * URL generation and caching, image resizing, rewriting, etc.
+     *
+     * You can use these read/write functions with callbacks, or have them return a Promise:
+     *
+     * 1) FilerUtils.writeFileAsBinary(filename, data, function(err) { ... });
+     *
+     * 2) FilerUtils.writeFileAsBinary(filename, data)
+     *      .done(function() { ... })
+     *      .fail(function(err) { ... });
+     */
+
+    function _readFile(filename, options, callback) {
+        var useCallback = typeof callback === "function";
+        var file;
+
+        try {
+            file = FileSystem.getFileForPath(filename);
+        } catch(err) {
+            if(useCallback) {
+                return callback(err);
+            }
+            return new $.Deferred().reject(err).promise();
+        }
+
+        if(typeof callback === "function") {
+            file.read(options, callback);
+        } else {
+            return Async.promisify(file, "read", options);
+        }
+    }
+
+    function _writeFile(filename, data, options, callback) {
+        var useCallback = typeof callback === "function";
+        var file;
+
+        try {
+            file = FileSystem.getFileForPath(filename);
+        } catch(err) {
+            if(useCallback) {
+                return callback(err);
+            }
+            return new $.Deferred().reject(err).promise();
+        }
+
+        if(typeof callback === "function") {
+            file.write(data, options, callback);
+        } else {
+            return Async.promisify(file, "write", data, options);
+        }
+    }
+
+    exports.readFileAsUTF8 = function(filename, callback) {
+        return _readFile(filename, {encoding: "utf8"}, callback);
+    };
+
+    exports.readFileAsBinary = function(filename, callback) {
+        return _readFile(filename, {encoding: null}, callback);
+    };
+
+    exports.writeFileAsUTF8 = function(filename, data, callback) {
+        return _writeFile(filename, data, {encoding: "utf8"}, callback);
+    };
+
+    exports.writeFileAsBinary = function(filename, data, callback) {
+        return _writeFile(filename, data, {encoding: null}, callback);
     };
 });

--- a/src/filesystem/impls/filer/RemoteFiler.js
+++ b/src/filesystem/impls/filer/RemoteFiler.js
@@ -9,6 +9,16 @@ define(function (require, exports, module) {
      * early, so that fs operations run quickly on startup.
      */
 
+    /**
+     * NOTE: For reading and writing UTF8 and Binary files, it is best/easiest
+     * to use the filesystem/impls/filer/FilerUtils module, since it does
+     * things at the right level of abstraction:
+     *  - readFileAsUTF8()
+     *  - readFileAsBinary()
+     *  - writeFileAsUTF8()
+     *  - writeFileASBinary()
+     */
+
     var fnQueue = require("filesystem/impls/filer/lib/queue");
     var ChannelUtils = require("bramble/ChannelUtils");
     var UUID = ChannelUtils.UUID;


### PR DESCRIPTION
This improves our filesystem read/write calls so that we are using the proper level of abstraction.  Doing so means that we don't have to refresh the URL cache, things like image resizing work, etc.

I've done it in such a way that you can either use callbacks or promises.  NOTE: I haven't changed every instance of `readFile` and `writeFile` because some of them are OK.  I also wonder if I've missed some, though.

Fixes https://github.com/mozilla/thimble.mozilla.org/issues/2323