### PR TITLE
Always show image filters when switching between images

### DIFF
--- a/src/editor/Image.js
+++ b/src/editor/Image.js
@@ -15,10 +15,10 @@ define(function (require, exports, module) {
         var $saveBtn = $(".btn-image-filter-save");
         var $resetBtn = $(".btn-image-filter-reset");
         var $imageWrapper = $(".image-view .image-wrapper");
-
-        $("#image-filters-section").removeClass("hide");
-
         var processing = false;
+
+        // Show the image filter buttons
+        $(".image-view .image-filters-section").removeClass("hide");
 
         $resetBtn.click(function() {
             image.reset();

--- a/src/htmlContent/image-view.html
+++ b/src/htmlContent/image-view.html
@@ -36,7 +36,7 @@
               </div>
             </div>
 
-            <div id="image-filters-section" class="hide">
+            <div class="image-filters-section hide">
               <div class="image-filter-actions">
                 <button class="btn btn-image-filter-reset" disabled="disabled">{{Strings.IMAGE_RESET_FILTERS}}</button>
                 <button class="btn btn-image-filter-save" disabled="disabled">{{Strings.IMAGE_SAVE_WITH_FILTERS}}</button>


### PR DESCRIPTION
We have a bug, where we were using an `id` vs. a `class` for the image filters div, and sometimes you can have more than one open at a time (not visible, but loaded in the DOM).

STR:
* drag 2 images into your filetree
* select one of them
* refresh the browser (so it loads this image view first)
* try switching back and forth between images, only 1 will have the filters.

This change switches it to a `class` so we can have more than one, and query to find and remove the `hide` class.