### PR TITLE
Implemented logic for unique rooms

### DIFF
--- a/src/editor/Collaboration.js
+++ b/src/editor/Collaboration.js
@@ -15,7 +15,7 @@ define(function (require, exports, module) {
         //To be moved to the bramble API.
         var query = (new URL(window.location.href)).searchParams;
         this.room = query.get("collaboration") || Math.random().toString(36).substring(7);
-        console.log("Link -> http://localhost:8000/src/hosted.html?collaboration=" + this.room);
+        console.log(this.room);
         this.webrtc = webrtc;
         this.pending = []; // pending clients that need to be initialized.
         this.changing = false;

--- a/src/editor/Collaboration.js
+++ b/src/editor/Collaboration.js
@@ -13,8 +13,8 @@ define(function (require, exports, module) {
             autoRequestMedia: false
         });
         //To be moved to the bramble API.
-        var params = window.location.href.split("?").pop();
-        this.room = new URLSearchParams(params).get("collaboration") || Math.random().toString(36).substring(7);
+        var query = (new URL(window.location.href)).searchParams;
+        this.room = query.get("collaboration") || Math.random().toString(36).substring(7);
         console.log("Link -> http://localhost:8000/src/hosted.html?collaboration=" + this.room);
         this.webrtc = webrtc;
         this.pending = []; // pending clients that need to be initialized.

--- a/src/editor/Collaboration.js
+++ b/src/editor/Collaboration.js
@@ -13,14 +13,9 @@ define(function (require, exports, module) {
             autoRequestMedia: false
         });
         //To be moved to the bramble API.
-        var hash = window.location.hash.replace(/^#/, "");
-        var m = /&?collaboration=([^&]*)/.exec(hash);
-        if(m && m[1]) {
-            this.room = m[1];
-        } else {
-            this.room = Math.random().toString(36).substring(7);
-        }
-        console.log("Link -> http://localhost:8000/src/hosted.html#?collaboration=" + this.room);
+        var params = window.location.href.split("?").pop();
+        this.room = new URLSearchParams(params).get("collaboration") || Math.random().toString(36).substring(7);
+        console.log("Link -> http://localhost:8000/src/hosted.html?collaboration=" + this.room);
         this.webrtc = webrtc;
         this.pending = []; // pending clients that need to be initialized.
         this.changing = false;

--- a/src/editor/Collaboration.js
+++ b/src/editor/Collaboration.js
@@ -12,7 +12,8 @@ define(function (require, exports, module) {
             // immediately ask for camera access
             autoRequestMedia: false
         });
-        var hash = location.hash.replace(/^#/, "");
+        //To be moved to the bramble API.
+        var hash = window.location.hash.replace(/^#/, "");
         var m = /&?collaboration=([^&]*)/.exec(hash);
         if(m && m[1]) {
             this.room = m[1];
@@ -27,7 +28,7 @@ define(function (require, exports, module) {
 
     Collaboration.prototype.init = function(codemirror) {
         var self = this;
-        this.webrtc.joinRoom("brackets-"+this.room, function() {
+        this.webrtc.joinRoom(this.room, function() {
             self.codemirror = codemirror;
             self.webrtc.sendToAll("new client", {});
             self.webrtc.on("createdPeer", function(peer) {

--- a/src/editor/Collaboration.js
+++ b/src/editor/Collaboration.js
@@ -12,6 +12,14 @@ define(function (require, exports, module) {
             // immediately ask for camera access
             autoRequestMedia: false
         });
+        var hash = location.hash.replace(/^#/, "");
+        var m = /&?collaboration=([^&]*)/.exec(hash);
+        if(m && m[1]) {
+            this.room = m[1];
+        } else {
+            this.room = Math.random().toString(36).substring(7);
+        }
+        console.log("Link -> http://localhost:8000/src/hosted.html#?collaboration=" + this.room);
         this.webrtc = webrtc;
         this.pending = []; // pending clients that need to be initialized.
         this.changing = false;
@@ -19,7 +27,7 @@ define(function (require, exports, module) {
 
     Collaboration.prototype.init = function(codemirror) {
         var self = this;
-        this.webrtc.joinRoom('thimble', function() {
+        this.webrtc.joinRoom("brackets-"+this.room, function() {
             self.codemirror = codemirror;
             self.webrtc.sendToAll("new client", {});
             self.webrtc.on("createdPeer", function(peer) {

--- a/src/hosted.js
+++ b/src/hosted.js
@@ -93,11 +93,11 @@
     }
 
     function load(Bramble) {
-        var hash = window.location.hash.replace(/^#/, "");
-        var m = /&?collaboration=([^&]*)/.exec(hash);
         var url = "index.html";
-        if(m && m[1]) {
-            url = url + "#&collaboration=" + m[1];
+        var params = window.location.href.split("?").pop();
+        var room = new URLSearchParams(params).get("collaboration");
+        if(room) {
+            url = url + "?collaboration=" + room;
         }
         Bramble.load("#bramble",{
             url: url,

--- a/src/hosted.js
+++ b/src/hosted.js
@@ -93,8 +93,14 @@
     }
 
     function load(Bramble) {
+        var hash = location.hash.replace(/^#/, "");
+        var m = /&?collaboration=([^&]*)/.exec(hash);
+        var url = "index.html";
+        if(m && m[1]) {
+            url = url + "#&collaboration=" + m[1];
+        }
         Bramble.load("#bramble",{
-            url: "index.html",
+            url: url,
             useLocationSearch: true
         });
 

--- a/src/hosted.js
+++ b/src/hosted.js
@@ -93,7 +93,7 @@
     }
 
     function load(Bramble) {
-        var hash = location.hash.replace(/^#/, "");
+        var hash = window.location.hash.replace(/^#/, "");
         var m = /&?collaboration=([^&]*)/.exec(hash);
         var url = "index.html";
         if(m && m[1]) {

--- a/src/hosted.js
+++ b/src/hosted.js
@@ -93,14 +93,11 @@
     }
 
     function load(Bramble) {
-        var url = "index.html";
-        var params = window.location.href.split("?").pop();
-        var room = new URLSearchParams(params).get("collaboration");
-        if(room) {
-            url = url + "?collaboration=" + room;
-        }
+        var query = (new URL(window.location.href)).searchParams;
+        var room = query.get("collaboration");
+
         Bramble.load("#bramble",{
-            url: url,
+            url: "index.html",
             useLocationSearch: true
         });
 

--- a/src/hosted.js
+++ b/src/hosted.js
@@ -93,9 +93,6 @@
     }
 
     function load(Bramble) {
-        var query = (new URL(window.location.href)).searchParams;
-        var room = query.get("collaboration");
-
         Bramble.load("#bramble",{
             url: "index.html",
             useLocationSearch: true


### PR DESCRIPTION
Implemented logic for unique rooms.

Currently in #801, there was a single room "thimble" as identified by WebRTC.
See https://github.com/mozilla/brackets/pull/801/files#diff-172c2aa71bb7326386a85125ccd13603R22

This PR implements unique rooms for each user. 
If a user goes to `localhost:8000/src/hosted.html`, a link is generated for the user which he/she can share with other users.
See console for the room link.
