### PR TITLE
Fix Thimble 2314 - deal with dirs and child paths in UrlCache.rename()/remove()

### DIFF
--- a/src/filesystem/impls/filer/FilerFileSystem.js
+++ b/src/filesystem/impls/filer/FilerFileSystem.js
@@ -195,16 +195,24 @@ define(function (require, exports, module) {
                 return callback(_mapError(err));
             }
 
-            UrlCache.rename(oldPath, newPath, function(err, removed) {
+            UrlCache.rename(oldPath, newPath, function(err) {
                 if(err) {
                     return callback(_mapError(err));
                 }
 
-                removed.forEach(function(pathInfo) {
-                    BrambleEvents.triggerFileRenamed(pathInfo.oldPath, pathInfo.newPath);
-                });
+                // NOTE: we deal with rename events per file higher-up in the Bramble API.
+                // and only send a single event for a file rename here vs. a folder + children.
+                stat(newPath, function(err, stat) {
+                    if(err) {
+                        return callback(_mapError(err));
+                    }
 
-                callback();
+                    if(stat.isFile) {
+                        BrambleEvents.triggerFileRenamed(oldPath, newPath);
+                    }
+
+                    callback();
+                });
             });
         }
 

--- a/src/filesystem/impls/filer/FilerFileSystem.js
+++ b/src/filesystem/impls/filer/FilerFileSystem.js
@@ -190,34 +190,25 @@ define(function (require, exports, module) {
         oldPath = decodePath(oldPath);
         newPath = decodePath(newPath);
 
-        function updateBlobURL(err) {
+        function updateURL(err) {
             if(err) {
                 return callback(_mapError(err));
             }
 
-            // If this was a rename on a file path, update the Blob cache too
-            stat(newPath, function(err, stat) {
+            UrlCache.rename(oldPath, newPath, function(err, removed) {
                 if(err) {
                     return callback(_mapError(err));
                 }
 
-                if(stat.isFile) {
-                    UrlCache.rename(oldPath, newPath, function(err) {
-                        if(err) {
-                            return callback(_mapError(err));
-                        }
+                removed.forEach(function(pathInfo) {
+                    BrambleEvents.triggerFileRenamed(pathInfo.oldPath, pathInfo.newPath);
+                });
 
-                        BrambleEvents.triggerFileRenamed(oldPath, newPath);
-                        callback();
-                    });
-                } else {
-                    // This is a dir, refresh our cache for child paths to get updated.
-                    FileSystemCache.refresh(callback);
-                }
+                callback();
             });
         }
 
-        fs.rename(oldPath, newPath, _wrap(updateBlobURL));
+        fs.rename(oldPath, newPath, _wrap(updateURL));
     }
 
     function readFile(path, options, callback) {
@@ -274,7 +265,7 @@ define(function (require, exports, module) {
         options = options || {};
         options.encoding = options.encoding === null ? null : "utf8";
 
-        // We rewrite and create a BLOB URL in Bramble, then run the
+        // We rewrite and create a URL in Bramble, then run the
         // remote FS operation, such that resources are ready when needed later.
         function _finishWrite(created) {
             var result = {};
@@ -298,8 +289,7 @@ define(function (require, exports, module) {
                 function step1RewriteAndCache(callback) {
                     var ext = Path.extname(path);
 
-                    // Add a BLOB cache record for this filename
-                    // only if it's not an HTML file
+                    // Add a cache record for this filename only if it's not an HTML file
                     if(Content.isHTML(ext)) {
                         return callback();
                     }

--- a/src/filesystem/impls/filer/UrlCache.js
+++ b/src/filesystem/impls/filer/UrlCache.js
@@ -272,9 +272,7 @@ define(function (require, exports, module) {
              .done(function() {
                  callback(null, removed);
              })
-             .fail(function(err) {
-                 callback(err);
-             });
+             .fail(callback);
     };
     CacheStorageUrlProvider.prototype.rename = function(oldPath, newPath, callback) {
         var self = this;
@@ -339,9 +337,7 @@ define(function (require, exports, module) {
              .done(function() {
                  callback(null, renamed);
              })
-             .fail(function(err) {
-                 callback(err);
-             });
+             .fail(callback);
     };
 
 

--- a/src/filesystem/impls/filer/UrlCache.js
+++ b/src/filesystem/impls/filer/UrlCache.js
@@ -109,12 +109,13 @@ define(function (require, exports, module) {
         });
     };
     BlobUrlProvider.prototype.remove = function(path, callback) {
-        var self = this;
+        var urls = this.urls;
+        var paths = this.paths;
         var removed = [];
 
         // If this is a dir path, look for other paths entries below it
-        Object.keys(self.urls).forEach(function(key) {
-            var url = self.urls[key];
+        Object.keys(urls).forEach(function(key) {
+            var url = urls[key];
 
             // The first time a file is written, we won't have
             // a stale cache entry to clean up.
@@ -127,8 +128,8 @@ define(function (require, exports, module) {
             if(key === path || key.indexOf(path + "/") === 0) {
                 removed.push(key);
 
-                delete self.urls[key];
-                delete self.paths[url];
+                delete urls[key];
+                delete paths[url];
 
                 // Delete the reference from memory
                 URL.revokeObjectURL(url);
@@ -138,13 +139,29 @@ define(function (require, exports, module) {
         _.defer(callback, null, removed);
     };
     BlobUrlProvider.prototype.rename = function(oldPath, newPath, callback) {
-        var url = this.urls[oldPath];
+        var urls = this.urls;
+        var paths = this.paths;
+        var renamed = [];
 
-        this.urls[newPath] = url;
-        this.paths[url] = newPath;
-        delete this.urls[oldPath];
+        // Deal with filenames and dirs (rename child paths entries below it)
+        Object.keys(urls).forEach(function(path) {
+            // If this filename matches exactly, or  filenames begin with "<path>/..."
+            if(path === oldPath || path.indexOf(oldPath + "/") === 0) {
+                var url = urls[path];
+                var renamedPath = path.replace(oldPath, newPath);
 
-        _.defer(callback);
+                urls[renamedPath] = url;
+                paths[url] = renamedPath;
+                delete urls[path];
+
+                renamed.push({
+                    oldPath: oldPath,
+                    newPath: renamedPath
+                });
+            }
+        });
+
+        _.defer(callback, null, renamed);
     };
 
 
@@ -261,33 +278,70 @@ define(function (require, exports, module) {
     };
     CacheStorageUrlProvider.prototype.rename = function(oldPath, newPath, callback) {
         var self = this;
-        var oldUrl = self.urls[oldPath];
+        var urls = this.urls;
+        var paths = this.paths;
+        var projectCacheName = this.projectCacheName;
+        var renamed = [];
 
-        // Get the existing Response, and re-cache it with a new Request
-        // which uses the correct path/url.
-        window.caches
-            .open(self.projectCacheName)
-            .then(function(cache) {
-                cache.match(oldUrl).then(function(response) {
-                    var type = Content.mimeFromExt(Path.extname(newPath));
-                    var headers = new Headers();
-                    headers.append("Content-Type", type);
+        function _maybeRename(pathPart) {
+            var deferred = new $.Deferred();
 
-                    var newUrl = self.generateVFSUrlForPath(newPath);
-                    var request = new Request(newUrl, {
-                        method: "GET",
-                        headers: headers
+            // If this filename doesn't match exactly, or path doesn't begin with "<path>/..."
+            if(!(pathPart === oldPath || pathPart.indexOf(oldPath + "/") === 0)) {
+                return deferred.resolve().promise();
+            }
+
+            var oldUrl = urls[pathPart];
+            var renamedPath = pathPart.replace(oldPath, newPath);
+
+            // Get the existing Response, and re-cache it with a new Request
+            // which uses the correct path/url.
+            window.caches
+                .open(projectCacheName)
+                .then(function(cache) {
+                    cache.match(oldUrl).then(function(response) {
+                        var type = Content.mimeFromExt(Path.extname(renamedPath));
+                        var headers = new Headers();
+                        headers.append("Content-Type", type);
+
+                        var newUrl = self.generateVFSUrlForPath(renamedPath);
+                        var request = new Request(newUrl, {
+                            method: "GET",
+                            headers: headers
+                        });
+
+                        urls[renamedPath] = newUrl;
+                        paths[newUrl] = renamedPath;
+
+                        cache.put(request, response.clone()).then(function() {
+                            self.remove(pathPart, function(err) {
+                                if(err) {
+                                    return deferred.reject(err);
+                                }
+
+                                renamed.push({
+                                    oldPath: oldPath,
+                                    newPath: renamedPath
+                                });
+
+                                deferred.resolve();
+                            });
+                        });
                     });
+                })
+                .catch(deferred.reject);
 
-                    self.urls[newPath] = newUrl;
-                    self.paths[newUrl] = newPath;
+            return deferred.promise();
+        }
 
-                    cache.put(request, response.clone()).then(function() {
-                        self.remove(oldPath, callback);
-                    });
-                });
-            })
-            .catch(callback);
+        // Deal with renaming a file, or a dir (and all children)
+        Async.doSequentially(Object.keys(self.urls), _maybeRename, false)
+             .done(function() {
+                 callback(null, renamed);
+             })
+             .fail(function(err) {
+                 callback(err);
+             });
     };
 
 


### PR DESCRIPTION
This fixes https://github.com/mozilla/thimble.mozilla.org/issues/2314 by examining cached paths to locate child paths when we rename or remove a parent dir.