### PR TITLE
fix: Deprecation warning on Bramble Url code hints

### DIFF
--- a/src/extensions/default/BrambleUrlCodeHints/main.js
+++ b/src/extensions/default/BrambleUrlCodeHints/main.js
@@ -40,6 +40,7 @@ define(function (require, exports, module) {
         EditorManager   = brackets.getModule("editor/EditorManager"),
         Path            = brackets.getModule("filesystem/impls/filer/FilerUtils").Path,
         StartupState    = brackets.getModule("bramble/StartupState"),
+        PathUtils       = brackets.getModule("thirdparty/path-utils/path-utils"),
         Camera          = require("camera/index"),
         Selfie          = require("selfie"),
 
@@ -82,7 +83,6 @@ define(function (require, exports, module) {
         docDir = FileUtils.getDirectoryPath(doc.file.fullPath);
 
         // get relative path from query string
-        var PathUtils = brackets.getModule("thirdparty/path-utils/path-utils");
         queryUrl = PathUtils.parseUrl(query.queryStr);
         if (queryUrl) {
             queryDir = queryUrl.directory;

--- a/src/extensions/default/BrambleUrlCodeHints/main.js
+++ b/src/extensions/default/BrambleUrlCodeHints/main.js
@@ -82,7 +82,8 @@ define(function (require, exports, module) {
         docDir = FileUtils.getDirectoryPath(doc.file.fullPath);
 
         // get relative path from query string
-        queryUrl = window.PathUtils.parseUrl(query.queryStr);
+        var PathUtils = brackets.getModule("thirdparty/path-utils/path-utils");
+        queryUrl = PathUtils.parseUrl(query.queryStr);
         if (queryUrl) {
             queryDir = queryUrl.directory;
         }


### PR DESCRIPTION
Fixes: mozilla/thimble.mozilla.org#2268

Using thirdparty-pathutils to remove deprecation warning

![deprecation](https://user-images.githubusercontent.com/19590302/27898002-365330f6-6213-11e7-91f8-ffa3ef5605b2.gif)

{we don't see any deprecation warning in the console}