### PR TITLE
Shifted turn server locally.

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,9 @@
         "preproduction": "grunt build-browser-compressed && npm run unlocalize",
         "production": "npm start -- --gzip",
         "test": "grunt test && grunt build-browser-compressed",
-        "server": "concurrently \"http-server -p 8000 --cors\" \"node node_modules/signal-master/server.js \"",
+        "server:webrtc": "node node_modules/signal-master",
+        "server:static": "http-server -p 8000 --cors",
+        "server": "concurrently \"npm run server:webrtc\" \"npm run server:static\"",
         "prestart": "npm run localize && grunt build-browser-dev",
         "start": "npm run server || true",
         "poststart": "npm run unlocalize"

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
         "anymatch": "1.3.0",
         "aws-sdk": "^2.19.0",
         "chokidar": "1.6.0",
+        "concurrently": "^3.5.0",
         "glob": "7.0.6",
         "grunt": "0.4.5",
         "grunt-cleanempty": "1.0.3",
@@ -46,8 +47,9 @@
         "pica": "^3.0.4",
         "q": "1.4.1",
         "semver": "^4.1.0",
-        "wolfy87-eventemitter": "^5.1.0",
+        "signal-master": "^1.0.1",
         "simplewebrtc": "^3.0.0",
+        "wolfy87-eventemitter": "^5.1.0",
         "xmldoc": "^0.1.2"
     },
     "devDependencies": {
@@ -73,7 +75,7 @@
         "preproduction": "grunt build-browser-compressed && npm run unlocalize",
         "production": "npm start -- --gzip",
         "test": "grunt test && grunt build-browser-compressed",
-        "server": "http-server -p 8000 --cors",
+        "server": "concurrently \"http-server -p 8000 --cors\" \"node node_modules/signal-master/server.js \"",
         "prestart": "npm run localize && grunt build-browser-dev",
         "start": "npm run server || true",
         "poststart": "npm run unlocalize"

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
         "anymatch": "1.3.0",
         "aws-sdk": "^2.19.0",
         "chokidar": "1.6.0",
-        "concurrently": "^3.5.0",
         "glob": "7.0.6",
         "grunt": "0.4.5",
         "grunt-cleanempty": "1.0.3",
@@ -47,13 +46,13 @@
         "pica": "^3.0.4",
         "q": "1.4.1",
         "semver": "^4.1.0",
-        "signal-master": "^1.0.1",
         "simplewebrtc": "^3.0.0",
         "wolfy87-eventemitter": "^5.1.0",
         "xmldoc": "^0.1.2"
     },
     "devDependencies": {
         "bluebird": "^3.4.7",
+        "concurrently": "^3.5.0",
         "grunt-newer": "^1.3.0",
         "gunzip-maybe": "^1.3.1",
         "http-server": "mozilla/http-server#gzip",
@@ -63,6 +62,7 @@
         "request": "^2.69.0",
         "requirejs": "^2.3.3",
         "rimraf": "^2.6.1",
+        "signal-master": "^1.0.1",
         "sw-precache": "^5.0.0",
         "tar-fs": "^1.15.1"
     },

--- a/src/editor/Collaboration.js
+++ b/src/editor/Collaboration.js
@@ -10,7 +10,9 @@ define(function (require, exports, module) {
             // the id/element dom element that will hold remote videos
             remoteVideosEl: 'remotesVideos',
             // immediately ask for camera access
-            autoRequestMedia: false
+            autoRequestMedia: false,
+            // TODO : Shift this to config.
+            url: "localhost:8888"
         });
         this.webrtc = webrtc;
         this.pending = []; // pending clients that need to be initialized.


### PR DESCRIPTION
Right now we are using google's server `stun:stun1.l.google.com:19302` for collaboration.
In reference to [#2350](https://github.com/mozilla/thimble.mozilla.org/issues/2350), we should shift to a local one.
This PR implements the same.