### PR TITLE
Fix #499: Add inline editor and inline doc provider querying and events

### DIFF
--- a/src/editor/CSSInlineEditor.js
+++ b/src/editor/CSSInlineEditor.js
@@ -363,29 +363,7 @@ define(function (require, exports, module) {
         return result.promise();
     }
 
-    function cssProviderQuery(hostEditor, pos) {
-        // Only provide a CSS editor when cursor is in HTML content
-        if (hostEditor.getLanguageForSelection().getId() !== "html") {
-            return false;
-        }
-
-        // Only provide CSS editor if the selection is within a single line
-        var sel = hostEditor.getSelection();
-        if (sel.start.line !== sel.end.line) {
-            return false;
-        }
-
-        // Always use the selection start for determining selector name. The pos
-        // parameter is usually the selection end.
-        var selectorResult = _getSelectorName(hostEditor, sel.start);
-        if (selectorResult.selectorName === "") {
-            return false;
-        }
-
-        return true;
-    }
-
-    EditorManager.registerInlineEditProvider(htmlToCSSProvider, cssProviderQuery);
+    EditorManager.registerInlineEditProvider(htmlToCSSProvider);
 
     _newRuleCmd = CommandManager.register(Strings.CMD_CSS_QUICK_EDIT_NEW_RULE, Commands.CSS_QUICK_EDIT_NEW_RULE, _handleNewRule);
     _newRuleCmd.setEnabled(false);

--- a/src/editor/CSSInlineEditor.js
+++ b/src/editor/CSSInlineEditor.js
@@ -363,7 +363,29 @@ define(function (require, exports, module) {
         return result.promise();
     }
 
-    EditorManager.registerInlineEditProvider(htmlToCSSProvider);
+    function cssProviderQuery(hostEditor, pos) {
+        // Only provide a CSS editor when cursor is in HTML content
+        if (hostEditor.getLanguageForSelection().getId() !== "html") {
+            return false;
+        }
+
+        // Only provide CSS editor if the selection is within a single line
+        var sel = hostEditor.getSelection();
+        if (sel.start.line !== sel.end.line) {
+            return false;
+        }
+
+        // Always use the selection start for determining selector name. The pos
+        // parameter is usually the selection end.
+        var selectorResult = _getSelectorName(hostEditor, sel.start);
+        if (selectorResult.selectorName === "") {
+            return false;
+        }
+
+        return true;
+    }
+
+    EditorManager.registerInlineEditProvider(htmlToCSSProvider, cssProviderQuery);
 
     _newRuleCmd = CommandManager.register(Strings.CMD_CSS_QUICK_EDIT_NEW_RULE, Commands.CSS_QUICK_EDIT_NEW_RULE, _handleNewRule);
     _newRuleCmd.setEnabled(false);

--- a/src/editor/EditorManager.js
+++ b/src/editor/EditorManager.js
@@ -66,8 +66,8 @@ define(function (require, exports, module) {
         InlineTextEditor    = require("editor/InlineTextEditor").InlineTextEditor,
         Strings             = require("strings"),
         LanguageManager     = require("language/LanguageManager"),
-        DeprecationWarning  = require("utils/DeprecationWarning");
-
+        DeprecationWarning  = require("utils/DeprecationWarning"),
+        InlineProviderIndicator = require("editor/InlineProviderIndicator");
 
     /**
      * Currently focused Editor (full-size, inline, or otherwise)
@@ -141,34 +141,6 @@ define(function (require, exports, module) {
         }
     }
 
-    /**
-     * Finds out if an editor provider exists for the given editor and position or not.
-     * Returns True if one does, otherwise False.
-     */
-    function _queryEditorProviders(editor) {
-        if(_queryProviders(editor, _inlineEditProviders)) {
-            console.log("editorProviderAvailable");
-            exports.trigger("editorProviderAvailable");
-        }
-    }
-
-    /**
-     * Finds out if a doc provider exists for the given editor and position or not.
-     * Returns True if one does, otherwise False.
-     */
-    function _queryDocProviders(editor) {
-        if(_queryProviders(editor, _inlineDocsProviders)) {
-            console.log("docProviderAvailable");
-            exports.trigger("docProviderAvailable");
-        }
-    }
-
-    function _checkCurrentPositionForProviders(e) {
-        var editor = e.target;
-        _queryEditorProviders(editor);
-        _queryDocProviders(editor);
-    }
-
     function _queryProviders(editor, providers) {
         var pos = editor.getCursorPos();
         for (var i = 0, len = providers.length; i < len; i++) {
@@ -178,6 +150,33 @@ define(function (require, exports, module) {
             }
         }
         return false;
+    }
+
+    /**
+     * Finds out if an editor provider exists for the given editor and position or not.
+     */
+    function _queryEditorProviders(editor) {
+        return _queryProviders(editor, _inlineEditProviders);
+    }
+
+    /**
+     * Finds out if a doc provider exists for the given editor and position or not.
+     */
+    function _queryDocProviders(editor) {
+        return _queryProviders(editor, _inlineDocsProviders);
+    }
+
+    function _checkCurrentPositionForProviders(e) {
+        var editor = e.target;
+        var editorProviderAvailable = _queryEditorProviders(editor);
+        var docsProviderAvailable = _queryDocProviders(editor);
+
+        if(!(editorProviderAvailable || docsProviderAvailable)) {
+            InlineProviderIndicator.hide();
+            return;
+        }
+
+        InlineProviderIndicator.show(editor, docsProviderAvailable, editorProviderAvailable);
     }
 
 	/**

--- a/src/editor/EditorManager.js
+++ b/src/editor/EditorManager.js
@@ -160,7 +160,6 @@ define(function (require, exports, module) {
     function _checkCurrentPositionForProviders(e) {
         var editor = e.target;
         var editorProviderAvailable = _queryEditorProviders(editor);
-
         if(editorProviderAvailable) {
             InlineProviderIndicator.show(editor);
         } else {

--- a/src/editor/EditorManager.js
+++ b/src/editor/EditorManager.js
@@ -290,8 +290,8 @@ define(function (require, exports, module) {
         // If one of them will provide a widget, show it inline once ready
         if (inlinePromise) {
             inlinePromise.done(function (inlineWidget) {
-                // XXXBramble: hide inline editor indicator if showing
-                InlineProviderIndicator.hide();
+                // XXXBramble: hide inline editor indicator if showing, and keep it closed until widget is closed
+                InlineProviderIndicator.disable();
 
                 editor.addInlineWidget(pos, inlineWidget).done(function () {
                     PerfUtils.addMeasurement(PerfUtils.INLINE_WIDGET_OPEN);
@@ -336,6 +336,9 @@ define(function (require, exports, module) {
                 // an inline widget's editor has focus, so close it
                 PerfUtils.markStart(PerfUtils.INLINE_WIDGET_CLOSE);
                 inlineWidget.close().done(function () {
+                    // XXXBramble: re-enable inline editor indicator
+                    InlineProviderIndicator.enable();
+
                     PerfUtils.addMeasurement(PerfUtils.INLINE_WIDGET_CLOSE);
                     // return a resolved promise to CommandManager
                     result.resolve(false);
@@ -419,6 +422,9 @@ define(function (require, exports, module) {
 
             hostEditor.focus();
         }
+
+        // XXXBramble: re-enable inline editor indicator
+        InlineProviderIndicator.enable();
 
         return hostEditor.removeInlineWidget(inlineWidget);
     }

--- a/src/editor/InlineProviderIndicator.js
+++ b/src/editor/InlineProviderIndicator.js
@@ -34,7 +34,6 @@ define(function (require, exports, module) {
         var coord = cm.charCoords(pos);
 
         if(disabled) {
-            console.log('bailing, disabled');
             return;
         }
 

--- a/src/editor/InlineProviderIndicator.js
+++ b/src/editor/InlineProviderIndicator.js
@@ -1,0 +1,43 @@
+define(function (require, exports, module) {
+    "use strict";
+
+    var PopoverWidget = require("editor/PopoverWidget");
+
+    var popoverContent = {
+        docsOnly: "<button type=\"button\" class=\"btn btn-default btn-doc-provider\">Docs</button>",
+        editorOnly: "<button type=\"button\" class=\"btn btn-default btn-editor-provider\">Editor</button>"
+    };
+
+    function hideIndicator() {
+        PopoverWidget.hide();
+    }
+
+    function showIndicator(editor, docsAvailable, editorAvailable) {
+        var cm = editor._codeMirror;
+        var pos = editor.getCursorPos();
+        var coord = cm.charCoords(pos);
+        var token = cm.getTokenAt(pos, true);
+
+        var content;
+        if(docsAvailable && editorAvailable) {
+            content = popoverContent.docsOnly + "&nbsp;" + popoverContent.editorOnly;
+        } else if (docsAvailable && !editorAvailable) {
+            content = popoverContent.docsOnly;
+        } else {
+            content = popoverContent.editorOnly;
+        }
+
+        var popover = {
+            editor: editor,
+            content: content,
+            xpos: coord.left,
+            ytop: coord.top,
+            ybot: coord.bottom
+        };
+
+        PopoverWidget.show(popover);
+    }
+
+    exports.show = showIndicator;
+    exports.hide = hideIndicator;
+});

--- a/src/editor/InlineProviderIndicator.js
+++ b/src/editor/InlineProviderIndicator.js
@@ -3,9 +3,21 @@ define(function (require, exports, module) {
 
     var Commands       = require("command/Commands");
     var CommandManager = require("command/CommandManager");
+    var AppInit        = require("utils/AppInit");
     var PopoverWidget  = require("editor/PopoverWidget");
 
-    var popoverContent = "<button type=\"button\" onclick=\"return window.triggerEditorProvider();\" class=\"btn btn-default btn-editor-provider\"></button>";
+    var popoverContent = "<span></span>";
+
+    var disabled = false;
+
+    function enable() {
+        disabled = false;
+    }
+
+    function disable() {
+        disabled = true;
+        hideIndicator();
+    }
 
     function triggerEditorProvider() {
         CommandManager.execute(Commands.TOGGLE_QUICK_EDIT);
@@ -22,20 +34,34 @@ define(function (require, exports, module) {
         var pos = editor.getCursorPos();
         var coord = cm.charCoords(pos);
 
+        if(disabled) {
+            return;
+        }
+
         var popover = {
             editor: editor,
             content: popoverContent,
             xpos: coord.left,
             ytop: coord.top,
-            ybot: coord.bottom
+            ybot: coord.bottom,
+            onClick: triggerEditorProvider
         };
 
         PopoverWidget.show(popover);
     }
 
+    function init() {
+        var editorHolder = $("#editor-holder")[0];
+        // Note: listening to "scroll" also catches text edits, which bubble a scroll event
+        // up from the hidden text area. This means/ we auto-hide on text edit, which is
+        // probably actually a good thing.
+        editorHolder.addEventListener("scroll", hideIndicator, true);
+    }
+
+    AppInit.appReady(init);
+
+    exports.enable = enable;
+    exports.disable = disable;
     exports.show = showIndicator;
     exports.hide = hideIndicator;
-
-    // HACK: for testing
-    window.triggerEditorProvider = triggerEditorProvider;
 });

--- a/src/editor/InlineProviderIndicator.js
+++ b/src/editor/InlineProviderIndicator.js
@@ -1,12 +1,26 @@
 define(function (require, exports, module) {
     "use strict";
 
-    var PopoverWidget = require("editor/PopoverWidget");
+    var Commands       = require("command/Commands");
+    var CommandManager = require("command/CommandManager");
+    var PopoverWidget  = require("editor/PopoverWidget");
 
     var popoverContent = {
-        docsOnly: "<button type=\"button\" class=\"btn btn-default btn-doc-provider\">Docs</button>",
-        editorOnly: "<button type=\"button\" class=\"btn btn-default btn-editor-provider\">Editor</button>"
+        docsOnly: "<button type=\"button\" onclick=\"return window.triggerDocsProvider();\" class=\"btn btn-default btn-doc-provider\">Docs</button>",
+        editorOnly: "<button type=\"button\" onclick=\"return window.triggerEditorProvider();\" class=\"btn btn-default btn-editor-provider\">Editor</button>"
     };
+
+    function triggerDocsProvider() {
+        CommandManager.execute(Commands.TOGGLE_QUICK_DOCS);
+        hideIndicator();
+        return false;
+    }
+
+    function triggerEditorProvider() {
+        CommandManager.execute(Commands.TOGGLE_QUICK_EDIT);
+        hideIndicator();
+        return false;
+    }
 
     function hideIndicator() {
         PopoverWidget.hide();
@@ -40,4 +54,8 @@ define(function (require, exports, module) {
 
     exports.show = showIndicator;
     exports.hide = hideIndicator;
+
+    // HACK: for testing
+    window.triggerDocsProvider = triggerDocsProvider;
+    window.triggerEditorProvider = triggerEditorProvider;
 });

--- a/src/editor/InlineProviderIndicator.js
+++ b/src/editor/InlineProviderIndicator.js
@@ -5,16 +5,7 @@ define(function (require, exports, module) {
     var CommandManager = require("command/CommandManager");
     var PopoverWidget  = require("editor/PopoverWidget");
 
-    var popoverContent = {
-        docsOnly: "<button type=\"button\" onclick=\"return window.triggerDocsProvider();\" class=\"btn btn-default btn-doc-provider\">Docs</button>",
-        editorOnly: "<button type=\"button\" onclick=\"return window.triggerEditorProvider();\" class=\"btn btn-default btn-editor-provider\"></button>"
-    };
-
-    function triggerDocsProvider() {
-        CommandManager.execute(Commands.TOGGLE_QUICK_DOCS);
-        hideIndicator();
-        return false;
-    }
+    var popoverContent = "<button type=\"button\" onclick=\"return window.triggerEditorProvider();\" class=\"btn btn-default btn-editor-provider\"></button>";
 
     function triggerEditorProvider() {
         CommandManager.execute(Commands.TOGGLE_QUICK_EDIT);
@@ -26,26 +17,14 @@ define(function (require, exports, module) {
         PopoverWidget.hide();
     }
 
-    function showIndicator(editor, docsAvailable, editorAvailable) {
+    function showIndicator(editor) {
         var cm = editor._codeMirror;
         var pos = editor.getCursorPos();
         var coord = cm.charCoords(pos);
-        var token = cm.getTokenAt(pos, true);
-
-        // var content;
-        // if(docsAvailable && editorAvailable) {
-            // content = popoverContent.editorOnly;
-        // } else if (docsAvailable && !editorAvailable) {
-            // content = popoverContent.docsOnly;
-        // } else {
-            // content = popoverContent.editorOnly;
-        // }
-
-        var content = popoverContent.editorOnly;
 
         var popover = {
             editor: editor,
-            content: content,
+            content: popoverContent,
             xpos: coord.left,
             ytop: coord.top,
             ybot: coord.bottom
@@ -58,6 +37,5 @@ define(function (require, exports, module) {
     exports.hide = hideIndicator;
 
     // HACK: for testing
-    window.triggerDocsProvider = triggerDocsProvider;
     window.triggerEditorProvider = triggerEditorProvider;
 });

--- a/src/editor/InlineProviderIndicator.js
+++ b/src/editor/InlineProviderIndicator.js
@@ -3,7 +3,6 @@ define(function (require, exports, module) {
 
     var Commands       = require("command/Commands");
     var CommandManager = require("command/CommandManager");
-    var AppInit        = require("utils/AppInit");
     var PopoverWidget  = require("editor/PopoverWidget");
 
     var popoverContent = "<span></span>";
@@ -35,6 +34,7 @@ define(function (require, exports, module) {
         var coord = cm.charCoords(pos);
 
         if(disabled) {
+            console.log('bailing, disabled');
             return;
         }
 
@@ -49,16 +49,6 @@ define(function (require, exports, module) {
 
         PopoverWidget.show(popover);
     }
-
-    function init() {
-        var editorHolder = $("#editor-holder")[0];
-        // Note: listening to "scroll" also catches text edits, which bubble a scroll event
-        // up from the hidden text area. This means/ we auto-hide on text edit, which is
-        // probably actually a good thing.
-        editorHolder.addEventListener("scroll", hideIndicator, true);
-    }
-
-    AppInit.appReady(init);
 
     exports.enable = enable;
     exports.disable = disable;

--- a/src/editor/PopoverWidget.js
+++ b/src/editor/PopoverWidget.js
@@ -27,10 +27,10 @@ define(function (require, exports, module) {
     "use strict";
 
     // Brackets modules
-    var EditorManager       = require("editor/EditorManager"),
-        ViewUtils           = require("utils/ViewUtils");
+    var EditorManager        = require("editor/EditorManager"),
+        ViewUtils            = require("utils/ViewUtils");
 
-    var popoverContainerHTML       = require("text!htmlContent/popover-template.html");
+    var popoverContainerHTML = require("text!htmlContent/popover-template.html");
 
     var $popoverContainer,
         $popoverContent;
@@ -50,15 +50,11 @@ define(function (require, exports, module) {
      * @type {{
      *      visible: boolean,
      *      editor: !Editor,
-     *      start: !{line, ch},             - start of matched text range
-     *      end: !{line, ch},               - end of matched text range
      *      content: !string,               - HTML content to display in popover
-     *      onShow: ?function():void,       - called once popover content added to the DOM (may never be called)
-     *        - if specified, must call positionPreview()
+     *      onClick: ?function():void,      - a click handler for the popover's contents
      *      xpos: number,                   - x of center of popover
      *      ytop: number,                   - y of top of matched text (when popover placed above text, normally)
      *      ybot: number,                   - y of bottom of matched text (when popover moved below text, avoiding window top)
-     *      marker: ?CodeMirror.TextMarker  - only set once visible==true
      * }}
      */
     var popoverState = null;
@@ -80,6 +76,10 @@ define(function (require, exports, module) {
             $popoverContent.empty();
             $popoverContainer.hide();
             $popoverContainer.removeClass("active");
+
+            if(popoverState.onClick) {
+                $popoverContent.off("click", popoverState.onClick);
+            }
         }
         popoverState = null;
     }
@@ -144,8 +144,11 @@ define(function (require, exports, module) {
 
         $popoverContent.append(popoverState.content);
         $popoverContainer.show();
-
         popoverState.visible = true;
+
+        if(popoverState.onClick) {
+            $popoverContent.on("click", popoverState.onClick);
+        }
 
         positionPopover(editor, popoverState.xpos, popoverState.ytop, popoverState.ybot);
     }

--- a/src/editor/PopoverWidget.js
+++ b/src/editor/PopoverWidget.js
@@ -1,0 +1,173 @@
+/*
+ * Copyright (c) 2013 - present Adobe Systems Incorporated. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ *
+ */
+
+/*jslint regexp: true */
+
+define(function (require, exports, module) {
+    "use strict";
+
+    // Brackets modules
+    var EditorManager       = require("editor/EditorManager"),
+        ViewUtils           = require("utils/ViewUtils");
+
+    var popoverContainerHTML       = require("text!htmlContent/popover-template.html");
+
+    var $popoverContainer,
+        $popoverContent;
+
+    // Constants
+    var POINTER_HEIGHT              = 15,   // Pointer height, used to shift popover above pointer (plus a little bit of space)
+        POPOVER_HORZ_MARGIN         =  5;   // Horizontal margin
+
+    /**
+     * There are three states for this var:
+     * 1. If null, there is no provider result for the given mouse position.
+     * 2. If non-null, and visible==true, there is a popover currently showing.
+     * 3. If non-null, but visible==false, we're waiting for HOVER_DELAY, which
+     *    is tracked by hoverTimer. The state changes to visible==true as soon as
+     *    there is a provider. If the mouse moves before then, timer is restarted.
+     *
+     * @type {{
+     *      visible: boolean,
+     *      editor: !Editor,
+     *      start: !{line, ch},             - start of matched text range
+     *      end: !{line, ch},               - end of matched text range
+     *      content: !string,               - HTML content to display in popover
+     *      onShow: ?function():void,       - called once popover content added to the DOM (may never be called)
+     *        - if specified, must call positionPreview()
+     *      xpos: number,                   - x of center of popover
+     *      ytop: number,                   - y of top of matched text (when popover placed above text, normally)
+     *      ybot: number,                   - y of bottom of matched text (when popover moved below text, avoiding window top)
+     *      marker: ?CodeMirror.TextMarker  - only set once visible==true
+     * }}
+     */
+    var popoverState = null;
+
+
+
+    // Popover widget management ----------------------------------------------
+
+    /**
+     * Cancels whatever popoverState was currently pending and sets it back to null. If the popover was visible,
+     * hides it; if the popover was invisible and still pending, cancels hoverTimer so it will never be shown.
+     */
+    function hidePopover() {
+        if (!popoverState) {
+            return;
+        }
+
+        if (popoverState.visible) {
+            $popoverContent.empty();
+            $popoverContainer.hide();
+            $popoverContainer.removeClass("active");
+        }
+        popoverState = null;
+    }
+
+    function positionPopover(editor, xpos, ypos, ybot) {
+        var previewWidth  = $popoverContainer.outerWidth(),
+            top           = ypos - $popoverContainer.outerHeight() - POINTER_HEIGHT,
+            left          = xpos - previewWidth / 2,
+            elementRect = {
+                top:    top,
+                left:   left - POPOVER_HORZ_MARGIN,
+                height: $popoverContainer.outerHeight() + POINTER_HEIGHT,
+                width:  previewWidth + 2 * POPOVER_HORZ_MARGIN
+            },
+            clip = ViewUtils.getElementClipSize($(editor.getRootElement()), elementRect);
+
+        // Prevent horizontal clipping
+        if (clip.left > 0) {
+            left += clip.left;
+        } else if (clip.right > 0) {
+            left -= clip.right;
+        }
+
+        // If clipped on top, flip popover below line
+        if (clip.top > 0) {
+            top = ybot + POINTER_HEIGHT;
+            $popoverContainer
+                .removeClass("bubble-above")
+                .addClass("bubble-below");
+        } else {
+            $popoverContainer
+                .removeClass("bubble-below")
+                .addClass("bubble-above");
+        }
+
+        $popoverContainer
+            .css({
+                left: left,
+                top: top
+            })
+            .addClass("active");
+    }
+
+    /**
+     * Changes the current hidden popoverState to visible, showing it in the UI and highlighting
+     * its matching text in the editor.
+     */
+    function show(popover) {
+        var editor = popover.editor;
+        var cm;
+
+        hidePopover();
+
+        if (!editor || !editor._codeMirror) {
+            hidePopover();
+            return;
+        }
+
+        cm = editor._codeMirror;
+
+        popoverState = popover;
+
+        $popoverContent.append(popoverState.content);
+        $popoverContainer.show();
+
+        popoverState.visible = true;
+
+        positionPopover(editor, popoverState.xpos, popoverState.ytop, popoverState.ybot);
+    }
+
+    function onActiveEditorChange(event, current, previous) {
+        // Hide preview when editor changes
+        hidePopover();
+
+        if (previous && previous.document) {
+            previous.document.off("change", hidePopover);
+        }
+
+        if (current && current.document) {
+            current.document.on("change", hidePopover);
+        }
+    }
+
+
+    // Create the preview container
+    $popoverContainer = $(popoverContainerHTML).appendTo($("body"));
+    $popoverContent = $popoverContainer.find(".content");
+
+    exports.show = show;
+    exports.hide = hidePopover;
+});

--- a/src/extensions/default/Inline3DParametersEditor/main.js
+++ b/src/extensions/default/Inline3DParametersEditor/main.js
@@ -115,7 +115,39 @@ define(function (require, exports, module) {
         return result.resolve(inline3DParameterEditor).promise();
     }
 
+    function queryInline3DParametersEditor(hostEditor, pos) {
+        var match, sel, tagInfo, cursorLine, ParameterRegex, start, end, endPos, marker;
+
+        sel = hostEditor.getSelection();
+        if (sel.start.line !== sel.end.line) {
+            return false;
+        }
+        var tagInfo = HTMLUtils.getTagInfo(hostEditor, sel.start);
+        if(!is3DParameter(tagInfo.tagName)) {
+            return false;
+        }
+
+        ParameterRegex = Inline3dParametersUtils.PARAMETERS_3D_REGEX;
+        ParameterRegex.lastIndex = 0;
+        cursorLine = hostEditor.document.getLine(pos.line);
+        match = ParameterRegex.exec(cursorLine);
+
+        // The loop returns the first match to the regex ParameterRegex
+        // Returns null in case no match is found
+        while(match) {
+            start = match.index;
+            end = start + match[0].trim().length;
+            if (pos.ch >= start && pos.ch <= end) {
+                break;
+            }
+            // look for the next match since a match containing the cursor is not found yet
+            match = ParameterRegex.exec(cursorLine);
+        }
+
+        return !!match;
+    }
+
     ExtensionUtils.loadStyleSheet(module, "css/main.less");
-    EditorManager.registerInlineEditProvider(inline3DParametersEditor);
+    EditorManager.registerInlineEditProvider(inline3DParametersEditor, queryInline3DParametersEditor);
     exports.prepareParametersForProvider = prepareParametersForProvider;
 });

--- a/src/extensions/default/QuickView/main.js
+++ b/src/extensions/default/QuickView/main.js
@@ -44,6 +44,9 @@ define(function (require, exports, module) {
         Path                = brackets.getModule("filesystem/impls/filer/BracketsFiler").Path,
         UrlCache           = brackets.getModule("filesystem/impls/filer/UrlCache");
 
+    // XXXBramble: we also show a similar indicator, and need to not have them fight for space
+    var InlineProviderIndicator = brackets.getModule("editor/InlineProviderIndicator");
+
     var previewContainerHTML       = require("text!QuickViewTemplate.html");
 
     var enabled,                             // Only show preview if true
@@ -137,6 +140,9 @@ define(function (require, exports, module) {
                 width:  previewWidth + 2 * POPOVER_HORZ_MARGIN
             },
             clip = ViewUtils.getElementClipSize($(editor.getRootElement()), elementRect);
+
+        // XXXBramble: hide the inline provider indicator if present so they don't fight.
+        InlineProviderIndicator.hide();
 
         // Prevent horizontal clipping
         if (clip.left > 0) {
@@ -558,8 +564,8 @@ define(function (require, exports, module) {
         var line = editor.document.getLine(pos.line);
 
         // FUTURE: Support plugin providers. For now we just hard-code...
-        var popover = colorAndGradientPreviewProvider(editor, pos, token, line) ||
-                      imagePreviewProvider(editor, pos, token, line);
+        // XXXBramble: we opt to not show the color preview, since we show an editor indicator instead.
+        var popover = imagePreviewProvider(editor, pos, token, line);
 
         if (popover) {
             // Providers return just { start, end, content, ?onShow, xpos, ytop, ybot }

--- a/src/extensions/extra/WebPlatformDocs/main.js
+++ b/src/extensions/extra/WebPlatformDocs/main.js
@@ -162,42 +162,8 @@ define(function (require, exports, module) {
         }
     }
 
-    function queryInlineDocsProvider(hostEditor, pos) {
-        var jsonFile, propInfo,
-            langId = hostEditor.getLanguageForSelection().getId(),
-            supportedLangs = ["css", "scss", "less", "html"],
-            langIndex = langId ? supportedLangs.indexOf(langId) : -1; // fail if langId is falsy
-
-        // Only provide docs when cursor is in supported language
-        if (langIndex < 0) {
-            return false;
-        }
-
-        // Only provide docs if the selection is within a single line
-        var sel = hostEditor.getSelection();
-        if (sel.start.line !== sel.end.line) {
-            return false;
-        }
-
-        // CSS-like language
-        if (langIndex <= 2) {
-            jsonFile = "css.json";
-            propInfo = CSSUtils.getInfoAtPos(hostEditor, sel.start);
-            return !!(propInfo.name);
-        }
-
-        // HTML
-        jsonFile = "html.json";
-        propInfo = HTMLUtils.getTagInfo(hostEditor, sel.start);
-        if (propInfo.position.tokenType === HTMLUtils.ATTR_NAME && propInfo.attr && propInfo.attr.name) {
-            return true;
-        }
-
-        return !!(propInfo.tagName);
-    }
-
     // Register as inline docs provider
-    EditorManager.registerInlineDocsProvider(inlineProvider, queryInlineDocsProvider);
+    EditorManager.registerInlineDocsProvider(inlineProvider);
 
     exports._getDocs         = getDocs;
     exports._inlineProvider  = inlineProvider;

--- a/src/extensions/extra/WebPlatformDocs/main.js
+++ b/src/extensions/extra/WebPlatformDocs/main.js
@@ -162,8 +162,42 @@ define(function (require, exports, module) {
         }
     }
 
+    function queryInlineDocsProvider(hostEditor, pos) {
+        var jsonFile, propInfo,
+            langId = hostEditor.getLanguageForSelection().getId(),
+            supportedLangs = ["css", "scss", "less", "html"],
+            langIndex = langId ? supportedLangs.indexOf(langId) : -1; // fail if langId is falsy
+
+        // Only provide docs when cursor is in supported language
+        if (langIndex < 0) {
+            return false;
+        }
+
+        // Only provide docs if the selection is within a single line
+        var sel = hostEditor.getSelection();
+        if (sel.start.line !== sel.end.line) {
+            return false;
+        }
+
+        // CSS-like language
+        if (langIndex <= 2) {
+            jsonFile = "css.json";
+            propInfo = CSSUtils.getInfoAtPos(hostEditor, sel.start);
+            return !!(propInfo.name);
+        }
+
+        // HTML
+        jsonFile = "html.json";
+        propInfo = HTMLUtils.getTagInfo(hostEditor, sel.start);
+        if (propInfo.position.tokenType === HTMLUtils.ATTR_NAME && propInfo.attr && propInfo.attr.name) {
+            return true;
+        }
+
+        return !!(propInfo.tagName);
+    }
+
     // Register as inline docs provider
-    EditorManager.registerInlineDocsProvider(inlineProvider);
+    EditorManager.registerInlineDocsProvider(inlineProvider, queryInlineDocsProvider);
 
     exports._getDocs         = getDocs;
     exports._inlineProvider  = inlineProvider;

--- a/src/htmlContent/popover-template.html
+++ b/src/htmlContent/popover-template.html
@@ -1,0 +1,4 @@
+<div id="popover-container">
+    <div class="content">
+    </div>
+</div>

--- a/src/styles/bramble.less
+++ b/src/styles/bramble.less
@@ -7,5 +7,8 @@
 // Brackets root stylesheet
 @import url("brackets.less");
 
+// Popover Widget for Inline Providers, etc.
+@import url("bramble_popover.less");
+
 // Thimble-specific overrides
 @import url("bramble_overrides.less");

--- a/src/styles/bramble_popover.less
+++ b/src/styles/bramble_popover.less
@@ -33,7 +33,7 @@
       box-shadow: 0 4px 15px @dark-bc-shadow-large;
     }
 
-    button {
+    span {
       padding: 0;
       margin: 0;
       border: none;
@@ -56,7 +56,6 @@
       &:active {
         background: linear-gradient(-225deg, #502bb5, #8e47c4);
       }
-
 
       &:active:after {
           transform: scale(.9);

--- a/src/styles/bramble_popover.less
+++ b/src/styles/bramble_popover.less
@@ -1,0 +1,141 @@
+@bc-highlight:                  rgba(255, 255, 255, 0.12);
+@bc-panel-bg:                   #dfe2e2;
+@bc-panel-bg-promoted:          #d4d7d7;
+@bc-shadow-large:               rgba(0, 0, 0, 0.5);
+@bc-shadow-small:               rgba(0, 0, 0, 0.06);
+@bc-text:                       #333;
+
+@dark-bc-highlight:             rgba(255, 255, 255, 0.06);
+@dark-bc-panel-bg:              #2c2c2c;
+@dark-bc-panel-bg-promoted:     #222;
+@dark-bc-shadow-large:          rgba(0, 0, 0, 0.5);
+@dark-bc-shadow-small:          rgba(0, 0, 0, 0.06);
+@dark-bc-text:                  #ccc;
+
+#popover-container {
+    display: none;
+
+    -webkit-transition: opacity 0.125s ease-in, -webkit-transform 0.125s;
+    transition: opacity 0.125s ease-in, transform 0.125s;
+
+    -webkit-transform: scale(0);
+    transform: scale(0);
+    opacity: 0;
+
+    background: @bc-panel-bg;
+    position: absolute;
+    z-index: 5000;
+    pointer-events: none;
+
+    padding: 8px;
+    text-align: center;
+
+    border-radius: 4px;
+    box-shadow: 0 4px 15px @bc-shadow-large;
+
+    .dark & {
+        background: @dark-bc-panel-bg;
+        box-shadow: 0 4px 15px @dark-bc-shadow-large;
+    }
+}
+
+#popover-container.active {
+    -webkit-transform: scale(1);
+    transform: scale(1);
+    opacity: 1;
+}
+
+#popover-container .content {
+    background-image: url(images/preview-bg.svg);
+    border-radius: 2px;
+    box-shadow: 0 -1px 2px @bc-shadow-small, 0 1px 0 @bc-highlight;
+
+    .dark & {
+        box-shadow: 0 -1px 2px @dark-bc-shadow-small, 0 1px 0 @dark-bc-highlight;
+        background-image: url(images/preview-bg-dark.svg);
+    }
+}
+
+/**
+#popover-container .color-swatch {
+    width: 40px;
+    height: 40px;
+    background-size: 100%;
+}
+
+#popover-container .image-preview {
+    line-height: 0;
+}
+
+#popover-container .image-preview img {
+    min-width: 100px;
+    max-width: 200px;
+    max-height: 200px;
+}
+
+#popover-container .img-size {
+    background-color: @bc-panel-bg-promoted;
+    border-top: 1px solid @bc-highlight;
+    font-size: 0.9em;
+    color: @bc-text;
+    padding-left: 3px;
+    margin-top: 0;
+    text-align: left;
+    text-shadow: 0 1px 0px @bc-highlight;
+
+    .dark & {
+        background-color: @dark-bc-panel-bg-promoted;
+        border-top: 1px solid @dark-bc-highlight;
+        color: @dark-bc-text;
+        text-shadow: 0 1px 0px @dark-bc-highlight;
+    }
+}
+**/
+
+#popover-container.bubble-above {
+    -webkit-transform-origin: center bottom;
+    transform-origin: center bottom;
+}
+
+#popover-container.bubble-above:before {
+    display: none;
+}
+
+#popover-container.bubble-above:after,
+#popover-container.bubble-below:before {
+    width: 0;
+    height: 0;
+    content: '';
+    position: absolute;
+    left: 50%;
+    bottom: -9px;
+    margin-left: -10px;
+    z-index: 999;
+    display: block;
+    border-top: 10px solid @bc-panel-bg;
+    border-left: 10px solid transparent;
+    border-right: 10px solid transparent;
+    -webkit-filter: drop-shadow(0px 1px 0 rgba(0, 0, 0, 0.18));
+
+    .dark & {
+        border-top: 10px solid @dark-bc-panel-bg;
+    }
+}
+
+#popover-container.bubble-below {
+    -webkit-transform-origin: center top;
+    transform-origin: center top;
+}
+
+#popover-container.bubble-below:before {
+    -webkit-filter: drop-shadow(0px 1px 0 rgba(255, 255, 255, 0.18));
+    filter: drop-shadow(0px 1px 0 rgba(255, 255, 255, 0.18));
+    -webkit-transform: rotate(180deg);
+    transform: rotate(180deg);
+    top: -9px;
+}
+
+#popover-container.bubble-below:after {
+    display: none;
+}
+

--- a/src/styles/bramble_popover.less
+++ b/src/styles/bramble_popover.less
@@ -25,7 +25,6 @@
     background: @bc-panel-bg;
     position: absolute;
     z-index: 5000;
-    pointer-events: none;
 
     padding: 8px;
     text-align: center;


### PR DESCRIPTION
I'm going to carry on work begun by @davidhuang1550 in https://github.com/mozilla/brackets/pull/617, but do it in a slightly different way.  Thanks for getting this started and prototyping the feature.

This currently lacks any UI, but does trigger events for `editorProviderAvailable` and `docProviderAvailable`, which indicate that one could open an inline provider for the current cursor position and get something useful.

NOTE: I've done all the providers except the JS function hints, since it requires an async check that is more involved.  We could add that later if we want, but I don't think it's as critical as the ones I've done.

I've got a lot of code duplication in here, and that could be improved.  Also, I need to get @flukeout to help me figure out a good UX for exposing this info to the user, so he/she can click something and use the inline provider.