### PR TITLE
Don't use cached contents when reading files with FilerUtils

### DIFF
--- a/src/filesystem/File.js
+++ b/src/filesystem/File.js
@@ -96,9 +96,12 @@ define(function (require, exports, module) {
         // for a default value; otherwise it could be the empty string, which is
         // falsey.
         //
-        // XXXBramble: we don't ever want to use the cached contents of an SVG file,
+        // XXXBramble: we often don't want to use the cached contents of a file,
         // since we allow switching between UTF8 and Binary representations at runtime.
-        if (this._contents !== null && this._stat &&
+        // We also special case SVG files, since we can flip our internal representation.
+        if (!options.ignoreCachedContents                                   &&
+            this._contents !== null                                         &&
+            this._stat                                                      &&
             FilerUtils.normalizeExtension(Path.extname(this._path)) !== ".svg") {
             callback(null, this._contents, this._stat);
             return;

--- a/src/filesystem/impls/filer/FilerUtils.js
+++ b/src/filesystem/impls/filer/FilerUtils.js
@@ -76,6 +76,10 @@ define(function (require, exports, module) {
             return new $.Deferred().reject(err).promise();
         }
 
+        // Because we might want the file as UTF8 or Binary, force the File module
+        // to re-read the file from disk vs. using whatever is cached.
+        options.ignoreCachedContents = true;
+
         if(typeof callback === "function") {
             file.read(options, callback);
         } else {


### PR DESCRIPTION
This fixes https://github.com/mozilla/thimble.mozilla.org/issues/2369, which is a regression caused by me consolidating our filer read/write API in Brackets, and Brackets return cached data vs. going to disk.

To test this:

* create a project
* type `bramble.export()` in your console
* make sure the exported zip file contains `index.html` and `style.css` that have content vs. being empty files.