### PR TITLE
Always show info dialog when done unzipping/untarring

### DIFF
--- a/src/extensions/default/UploadFiles/UploadFilesDialog.js
+++ b/src/extensions/default/UploadFiles/UploadFilesDialog.js
@@ -97,13 +97,9 @@ define(function (require, exports, module) {
                 // Turn off the other buttons
                 $fromComputerButton.off("click", self._handleFromComputer.bind(self));
                 $takeSelfieButton.off("click", self._handleTakeSelfie.bind(self));
-
-                // Switch to the upload spinner
-                $dragFilesAreaDiv.hide();
-                $uploadFilesDiv.show();
+                self.hide();
             },
             onfilesdone: function() {
-                self.hide();
                 self.destroy();
             },
             autoRemoveHandlers: true

--- a/src/filesystem/impls/filer/ArchiveUtils.js
+++ b/src/filesystem/impls/filer/ArchiveUtils.js
@@ -15,6 +15,10 @@ define(function (require, exports, module) {
     var Filer           = require("filesystem/impls/filer/BracketsFiler");
     var FilerUtils      = require("filesystem/impls/filer/FilerUtils");
     var saveAs          = require("thirdparty/FileSaver");
+    var Dialogs         = require("widgets/Dialogs");
+    var DefaultDialogs  = require("widgets/DefaultDialogs");
+    var Strings         = require("strings");
+    var StringUtils     = require("utils/StringUtils");
     var Buffer          = Filer.Buffer;
     var Path            = Filer.Path;
     var fs              = Filer.fs();
@@ -134,7 +138,18 @@ define(function (require, exports, module) {
                     return callback(err);
                 }
 
-                _refreshFilesystem(callback);
+                _refreshFilesystem(function(err) {
+                    if(err) {
+                        return callback(err);
+                    }
+
+                    Dialogs.showModalDialog(
+                        DefaultDialogs.DIALOG_ID_INFO,
+                        Strings.DND_SUCCESS_UNZIP_TITLE
+                    ).getPromise().then(function() {
+                        callback(null);
+                    }, callback);
+                });
             });
         }
 
@@ -257,7 +272,18 @@ define(function (require, exports, module) {
             untarWorker.terminate();
             untarWorker = null;
 
-            callback(err);
+            _refreshFilesystem(function(err) {
+                if(err) {
+                    return callback(err);
+                }
+
+                Dialogs.showModalDialog(
+                    DefaultDialogs.DIALOG_ID_INFO,
+                    Strings.DND_SUCCESS_UNTAR_TITLE
+                ).getPromise().then(function() {
+                    callback(null);
+                }, callback);
+            });
         }
 
         function writeCallback(err) {
@@ -267,7 +293,7 @@ define(function (require, exports, module) {
 
             pending--;
             if(pending === 0) {
-                _refreshFilesystem(finish);
+                finish(err);
             }
         }
 

--- a/src/filesystem/impls/filer/lib/LegacyFileImport.js
+++ b/src/filesystem/impls/filer/lib/LegacyFileImport.js
@@ -30,12 +30,9 @@ define(function (require, exports, module) {
 
     var _               = require("thirdparty/lodash"),
         Async           = require("utils/Async"),
-        Dialogs         = require("widgets/Dialogs"),
-        DefaultDialogs  = require("widgets/DefaultDialogs"),
         FileSystem      = require("filesystem/FileSystem"),
         FileUtils       = require("file/FileUtils"),
         Strings         = require("strings"),
-        StringUtils     = require("utils/StringUtils"),
         Filer           = require("filesystem/impls/filer/BracketsFiler"),
         Path            = Filer.Path,
         Content         = require("filesystem/impls/filer/lib/content"),
@@ -90,11 +87,7 @@ define(function (require, exports, module) {
                     return;
                 }
 
-                Dialogs.showModalDialog(
-                    DefaultDialogs.DIALOG_ID_INFO,
-                    Strings.DND_SUCCESS_UNZIP_TITLE,
-                    StringUtils.format(Strings.DND_SUCCESS_UNZIP, basename)
-                ).getPromise().then(deferred.resolve, deferred.reject);
+                deferred.resolve();
             });
         }
 
@@ -108,11 +101,7 @@ define(function (require, exports, module) {
                     return;
                 }
 
-                Dialogs.showModalDialog(
-                    DefaultDialogs.DIALOG_ID_INFO,
-                    Strings.DND_SUCCESS_UNTAR_TITLE,
-                    StringUtils.format(Strings.DND_SUCCESS_UNTAR, basename)
-                ).getPromise().then(deferred.resolve, deferred.reject);
+                deferred.resolve();
             });
         }
 

--- a/src/filesystem/impls/filer/lib/WebKitFileImport.js
+++ b/src/filesystem/impls/filer/lib/WebKitFileImport.js
@@ -30,8 +30,6 @@ define(function (require, exports, module) {
 
     var _               = require("thirdparty/lodash"),
         Async           = require("utils/Async"),
-        Dialogs         = require("widgets/Dialogs"),
-        DefaultDialogs  = require("widgets/DefaultDialogs"),
         FileSystem      = require("filesystem/FileSystem"),
         FileUtils       = require("file/FileUtils"),
         Strings         = require("strings"),


### PR DESCRIPTION
This fixes https://github.com/mozilla/thimble.mozilla.org/issues/2331.  I'm not sure if it's going to feel right in all cases, though, but we can test it and see.

To test, you can import a `.zip` or `.tar` file in one of three ways:

* drag into file tree
* `bramble.showUploadDialog()` in your console then click `From Computer...`
* `bramble.showUploadDialog()` in your console then drag file into dialog
 
Depends on string change in https://github.com/mozilla/thimble.mozilla.org/pull/2390.