### PR TITLE
Always open dropped files if possible

### DIFF
--- a/src/filesystem/impls/filer/lib/FileImport.js
+++ b/src/filesystem/impls/filer/lib/FileImport.js
@@ -55,14 +55,18 @@ define(function (require, exports, module) {
         // If we are given a sub-dir within the project, use that.  Otherwise use project root.
         parentPath = parentPath || BrambleStartupState.project("root");
 
-        return strategy.import(source, parentPath, function(err) {
+        return strategy.import(source, parentPath, function(err, pathsToOpen) {
             if(err) {
                 return callback(err);
             }
-            FileSystemCache.refresh(function() {
-                LiveDevMultiBrowser.reload();
-                callback();
+
+            // Filter out any paths to open for which we can't provide an editor
+            pathsToOpen = pathsToOpen.filter(function(path) {
+                return Content.isEditable(Path.extname(path));
             });
+
+            LiveDevMultiBrowser.reload();
+            callback(null, pathsToOpen);
         });
     };
 });

--- a/src/filesystem/impls/filer/lib/content.js
+++ b/src/filesystem/impls/filer/lib/content.js
@@ -117,6 +117,20 @@ define(function (require, exports, module) {
     }
 
     module.exports = {
+        mimeFromExt: function(ext) {
+            return _lookupMimeType(ext);
+        },
+
+        // Whether or not we can provide a useful editor for this, and should try to open.
+        isEditable: function(ext) {
+            return this.isUTF8Encoded(ext) ||
+                   this.isImage(ext)       ||
+                   this.isAudio(ext)       ||
+                   this.isVideo(ext)       ||
+                   this.isFont(ext)        ||
+                   this.isPDF(ext);
+        },
+
         isImage: function(ext) {
             var info = new FileInfo(ext);
             return info.type === "image";
@@ -182,9 +196,6 @@ define(function (require, exports, module) {
             }
         },
 
-        mimeFromExt: function(ext) {
-            return _lookupMimeType(ext);
-        },
 
         // Whether or not this is a text/* mime type
         isTextType: function(mime) {

--- a/src/language/languages.json
+++ b/src/language/languages.json
@@ -68,12 +68,6 @@
         "isBinary": true
     },
 
-    "image": {
-        "name": "Image",
-        "fileExtensions": ["gif", "png", "jpe", "jpeg", "jpg", "ico", "bmp", "webp"],
-        "isBinary": true
-    },
-
     "binary": {
         "name": "Other Binary",
         "fileExtensions": [

--- a/src/utils/DragAndDrop.js
+++ b/src/utils/DragAndDrop.js
@@ -332,7 +332,7 @@ define(function (require, exports, module) {
                 });
         }
 
-        FileImport.import(source, _dropPathHint, function(err, paths) {
+        FileImport.import(source, _dropPathHint, function(err, pathsToOpen) {
             // Reset drop path, until we get an explicit one set in future.
             _dropPathHint = null;
 
@@ -342,9 +342,8 @@ define(function (require, exports, module) {
                 return;
             }
 
-            // Don't crash in legacy browsers if we rejected all paths (e.g., folder(s)).
-            paths = paths || [];
-            openDroppedFiles(paths);
+            pathsToOpen = pathsToOpen || [];
+            openDroppedFiles(pathsToOpen);
 
             callback();
         });


### PR DESCRIPTION
Fixes https://github.com/mozilla/thimble.mozilla.org/issues/2316.  Try this out and see what you think.  One thing I don't love is that it flashes through opening all the files when you import a `.zip`, which I think is a bit jarring.  Maybe we should add some code here to pick the *best* file to open when you have many and only open that one? For example, prefer an `.html` but then have a sliding scale for different types.

Please test this multiple ways:

* drag and drop 1 file into file tree
* drag multiple files and/or a folder into the file tree (folders only work in some browsers)
* use `bramble.showUploadDialog()` and use the drop area and "from computer"
* repeat all of about with a `.zip` and `.tar` file