### PR TITLE
Use Content Type info and Content module to pick icons

### DIFF
--- a/src/filesystem/impls/filer/lib/content.js
+++ b/src/filesystem/impls/filer/lib/content.js
@@ -30,10 +30,6 @@ define(function (require, exports, module) {
         case '.htm':
         // fallsthrough
         case '.htx':
-        // fallsthrough
-        case '.md':
-        // fallsthrough
-        case '.markdown':
             return 'text/html';
 
         // CSS
@@ -50,6 +46,14 @@ define(function (require, exports, module) {
         case '.json':
             return 'application/javascript';
         case '.txt':
+        // fallsthrough
+        case '.markdown':
+        // fallsthrough
+        case '.md':
+        // fallsthrough
+        case '.ini':
+        // fallsthrough
+        case '.cfg':
             return 'text/plain';
 
         // Images

--- a/src/filesystem/impls/filer/lib/content.js
+++ b/src/filesystem/impls/filer/lib/content.js
@@ -84,6 +84,8 @@ define(function (require, exports, module) {
 
         // Audio
         case '.oga':
+        // fallsthrough
+        case '.ogg':
             return 'audio/ogg';
         case '.mpa':
         // fallsthrough
@@ -145,6 +147,11 @@ define(function (require, exports, module) {
         isCSS: function(ext) {
             var id = _getLanguageId(ext);
             return id === "css";
+        },
+
+        isScript: function(ext) {
+            var info = new FileInfo(ext);
+            return info.subType === "javascript";
         },
 
         needsRewriting: function(ext) {

--- a/src/language/languages.json
+++ b/src/language/languages.json
@@ -1,7 +1,13 @@
 {
     "unknown": {
+        "name": "Unknown",
+        "isBinary": true
+    },
+
+    "text": {
         "name": "Text",
-        "mode": ["null", "text/plain"]
+        "mode": ["null", "text/plain"],
+        "fileExtensions": ["txt", "ini", "cfg"]
     },
 
     "css": {
@@ -60,12 +66,6 @@
         "mode": "markdown",
         "fileExtensions": ["md", "markdown", "mdown", "mkdn"],
         "blockComment": ["<!--", "-->"]
-    },
-
-    "image": {
-        "name": "Image",
-        "fileExtensions": ["gif", "png", "jpe", "jpeg", "jpg", "ico", "bmp", "webp"],
-        "isBinary": true
     },
 
     "image": {

--- a/src/project/FileTreeView.js
+++ b/src/project/FileTreeView.js
@@ -520,7 +520,7 @@ define(function (require, exports, module) {
             } else if (Content.isPDF(ext)) {
                 fileType = "pdf";
             } else {
-                fileType = LanguageManager.getLanguageForPath(fullname).isBinary() ? "binary" : "default";
+                fileType = "binary";
             }
 
             var insClassName = "jstree-icon-" + fileType;

--- a/src/project/FileTreeView.js
+++ b/src/project/FileTreeView.js
@@ -520,7 +520,13 @@ define(function (require, exports, module) {
             } else if (Content.isPDF(ext)) {
                 fileType = "pdf";
             } else {
-                fileType = "binary";
+                // If it doesn't match anything else, do one last check for a text/* type
+                // and if it isn't that, assume binary.
+                if (mime.indexOf("text/") === 0) {
+                    fileType = "default";
+                } else {
+                    fileType = "binary";
+                }
             }
 
             var insClassName = "jstree-icon-" + fileType;

--- a/src/project/FileTreeView.js
+++ b/src/project/FileTreeView.js
@@ -45,6 +45,11 @@ define(function (require, exports, module) {
         UrlCache          = require("filesystem/impls/filer/UrlCache"),
         Menus             = require("command/Menus");
 
+    // XXXBramble
+    var FilerUtils        = require("filesystem/impls/filer/FilerUtils"),
+        Path              = FilerUtils.Path,
+        Content           = require("filesystem/impls/filer/lib/content");
+
     var DOM = React.DOM;
 
     /**
@@ -492,72 +497,38 @@ define(function (require, exports, module) {
 
         render: function () {
             var fullname = this.props.name,
-                extension = LanguageManager.getCompoundFileExtension(fullname),
-                name = _getName(fullname, extension),
-                fileType = "default";
+                ext = LanguageManager.getCompoundFileExtension(fullname),
+                name = _getName(fullname, ext),
+                mime = Content.mimeFromExt(ext),
+                fileType;
 
-            switch (extension.toLowerCase()) {
-                case "htmls":
-                case "htm":
-                case "htx":
-                case "md":
-                case "markdown":
-                case "html":
-                case "xml":
-                case "xhtml":
-                    fileType = "html";
-                    break;
-                case "ico":
-                case "bmp":
-                case "svg":
-                case "png":
-                case "ico":
-                case "jpg":
-                case "jpe":
-                case "jpeg":
-                case "gif":
-                    fileType = "image";
-                    break;
-                case "eot":
-                case "woff":
-                case "otf":
-                case "ttf":
-                    fileType = "font";
-                    break;
-                case "mp3":
-                case "oga":
-                case "wav":
-                case "wave":
-                    fileType = "audio";
-                    break;
-                case "ogv":
-                case "mp4":
-                case "webm":
-                    fileType = "video";
-                    break;
-                case "css":
-                case "less":
-                    fileType = "css";
-                    break;
-                case "js":
-                case "jsx":
-                case "json":
-                    fileType = "js";
-                    break;
-                case "pdf":
-                    fileType = "pdf";
-                    break;
-                default:
-                    fileType = LanguageManager.getLanguageForPath(fullname).isBinary() ? "binary" : "default";
-                    break;
+            // Figure out which icon we want to show, relying on Content Type info.
+            if(Content.isHTML(ext)) {
+                fileType = "html";
+            } else if (Content.isImage(ext)) {
+                fileType = "image";
+            } else if (Content.isFont(ext)) {
+                fileType = "font";
+            } else if (Content.isAudio(ext)) {
+                fileType = "audio";
+            } else if (Content.isVideo(ext)) {
+                fileType = "video";
+            } else if (Content.isCSS(ext)) {
+                fileType = "css";
+            } else if (Content.isScript(ext)) {
+                fileType = "js";
+            } else if (Content.isPDF(ext)) {
+                fileType = "pdf";
+            } else {
+                fileType = LanguageManager.getLanguageForPath(fullname).isBinary() ? "binary" : "default";
             }
 
             var insClassName = "jstree-icon-" + fileType;
 
-            if (extension) {
-                extension = DOM.span({
+            if (ext) {
+                ext = DOM.span({
                     className: "extension"
-                }, "." + extension);
+                }, "." + ext);
             }
 
             var nameDisplay,
@@ -603,7 +574,7 @@ define(function (require, exports, module) {
                 DOM.span({
                     className: "menuToggle",
                     onClick: this.handleToggleClick
-                }),thickness, this.getIcons(), name, extension]);
+                }),thickness, this.getIcons(), name, ext]);
                 nameDisplay = DOM.a.apply(DOM.a, aArgs);
             }
 


### PR DESCRIPTION
Fixes https://github.com/mozilla/thimble.mozilla.org/issues/2364.  This moves the mapping of file extensions to mime type info into Content instead of duplicating the lists in the file tree rendering code.  I've also added `.ogg` for audio, since it was missing.