### PR TITLE
Correct mime type for wav files

### DIFF
--- a/src/filesystem/impls/filer/lib/content.js
+++ b/src/filesystem/impls/filer/lib/content.js
@@ -92,7 +92,7 @@ define(function (require, exports, module) {
         case '.wave':
         // fallsthrough
         case '.wav':
-            return 'audio/vnd.wave';
+            return 'audio/wav';
 
         // Web Fonts
         case '.eot':


### PR DESCRIPTION
Not sure why I used that mime type, but it's wrong.  This lets us play wav files correctly.