### PR TITLE
update incorrect overshoot calculation

### DIFF
--- a/src/filesystem/impls/filer/lib/ImageResizer.js
+++ b/src/filesystem/impls/filer/lib/ImageResizer.js
@@ -69,7 +69,7 @@ define(function (require, exports, module) {
             if (bufferSize < TARGET_SIZE * 0.5) {
                 return true;
             }
-            if (bufferSize > TARGET_SIZE * 0.66) {
+            if (bufferSize > TARGET_SIZE * 1.5) {
                 return true;
             }
             return false;


### PR DESCRIPTION
this updates the code such that it aligns with the code comment explaining what's supposed to happen: https://github.com/mozilla/brackets/blob/0b1df34a85dfb4874a0cfc4b3d7299916d84ebe6/src/filesystem/impls/filer/lib/ImageResizer.js#L66-L68

fixes https://github.com/mozilla/brackets/issues/863
