### PR TITLE
Deal with missing cached resources from live dev sw

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
         "request": "^2.69.0",
         "requirejs": "^2.3.3",
         "rimraf": "^2.6.1",
-        "sw-precache": "^5.0.0",
+        "sw-precache": "^5.2.0",
         "tar-fs": "^1.15.1"
     },
     "scripts": {

--- a/src/bramble-live-dev-cache-sw.js
+++ b/src/bramble-live-dev-cache-sw.js
@@ -5,6 +5,24 @@
  * which is named vfs/project/root.
  */
 
+// String comes from src/filesystem/impls/filer/UrlCache.js
+var liveDevUrlRegex = /thimble-sw-vfs-cached-url\//;
+
+function custom500() {
+    "use strict";
+
+    var body = "<!doctype html><title></title><p>There was an error serving your content. Try restarting your web browser to clear your cache.";
+    var init = {
+        status: 500,
+        statusText: "Thimble live dev server failed to find cached URL",
+        headers: {
+            "Content-Type": "text/html"
+        }
+    };
+
+    return new Response(body, init);
+}
+
 self.addEventListener("fetch", function(event) {
     "use strict";
 
@@ -15,7 +33,18 @@ self.addEventListener("fetch", function(event) {
         caches.match(url)
         .then(function(response) {
             // Either we have this file's response cached, or we should go to the network
-            return response || fetch(event.request);
+            if(response) {
+                return response;
+            }
+
+            // We expect to have a cached response for live dev URL requests, so it's
+            // odd that we don't.  Return a custom 500 indicating that something's wrong.
+            if(liveDevUrlRegex.test(url)) {
+                return custom500();
+            }
+
+            // Let this go through to the network
+            return fetch(event.request);
         })
         .catch(function(err) {
             console.warn("[Bramble Service Worker Error]: couldn't serve URL", url, err);

--- a/src/config.json
+++ b/src/config.json
@@ -87,7 +87,7 @@
         "request": "^2.69.0",
         "requirejs": "^2.3.3",
         "rimraf": "^2.6.1",
-        "sw-precache": "^5.0.0",
+        "sw-precache": "^5.2.0",
         "tar-fs": "^1.15.1"
     },
     "scripts": {

--- a/src/filesystem/impls/filer/UrlCache.js
+++ b/src/filesystem/impls/filer/UrlCache.js
@@ -13,6 +13,11 @@ define(function (require, exports, module) {
     var Path = FilerUtils.Path;
     var decodePath = FilerUtils.decodePath;
 
+    // Prefix for URLs that live in the virtual filesystem cache.
+    // NOTE: if you change this string, also update the regex in
+    // src/bramble-live-dev-cache-sw.js
+    var vfsPrefix = "thimble-sw-vfs-cached-url";
+
     var _provider;
 
     /**
@@ -171,17 +176,17 @@ define(function (require, exports, module) {
     function CacheStorageUrlProvider() {
         UrlProviderBase.call(this);
 
-        this.projectCacheName = Path.join("vfs", StartupState.project("root"));
+        this.projectCacheName = Path.join(vfsPrefix, StartupState.project("root"));
         this.baseUrl = this.generateVFSUrlForPath(StartupState.project("root")) + "/";
         this.shouldRewriteUrls = false;
     }
     CacheStorageUrlProvider.prototype = Object.create(UrlProviderBase.prototype);
     CacheStorageUrlProvider.prototype.constructor = CacheStorageUrlProvider;
 
-    // We use cache URLs like https://<origin>/dist/vfs/project/root/filename.ext
+    // We use cache URLs like https://<origin>/dist/thimble-vfs-cached-url/project/root/filename.ext
     CacheStorageUrlProvider.prototype.generateVFSUrlForPath = function(path) {
         var a = document.createElement("a");
-        a.href = StartupState.url("base") + "vfs" + path;
+        a.href = StartupState.url("base") + vfsPrefix + path;
         return a.href;
     };
 

--- a/src/filesystem/impls/filer/UrlCache.js
+++ b/src/filesystem/impls/filer/UrlCache.js
@@ -16,7 +16,7 @@ define(function (require, exports, module) {
     // Prefix for URLs that live in the virtual filesystem cache.
     // NOTE: if you change this string, also update the regex in
     // src/bramble-live-dev-cache-sw.js
-    var vfsPrefix = "thimble-sw-vfs-cached-url";
+    var vfsPrefix = "thimble-sw-vfs-cached-url" + "/" + brackets.getLocale();
 
     var _provider;
 


### PR DESCRIPTION
In https://github.com/mozilla/thimble.mozilla.org/issues/2381 and via support emails, we hear about users sometimes having their live dev preview not show the correct page, and instead show an S3 "missing key" 404 type page.  Why this is happening, I'm not sure, but the reason we do this is because the URL cache storage is obviously missing the resource it should have (i.e., we cache all files in the filesystem on project load, and also whenever we write to disk).

The most likely cause of this is that the service worker code is somehow not fully updated or the cached content is missing something.  One or more refreshes to force the service worker to update is necessary.  We need a way to communicate this.

In this PR I've added some custom checking to the service worker to see if the URL in question is a live dev URL that *should* be in cache and isn't.  When that happens, we'll return a custom 500 error page, which can have whatever we want in it.  Right now I did something very basic, and I'll get @flukeout to help me make it better:

![screen shot 2017-08-11 at 12 02 20 pm](https://user-images.githubusercontent.com/427398/29221740-d8a53278-7e8d-11e7-8fec-4147683c0387.png)

To simulate the situation where this happens, modify [this line of code](https://github.com/humphd/brackets/blob/891358fa352327cc2ed98e1d362a9f0287a5880f/src/filesystem/impls/filer/UrlCache.js#L222) to this:

```js
var request = new Request(url + "missing", {
```

This will cause all live dev URLs to be wrong, and force this custom error handler to kick in.

To do localized versions of this page, we'll have to generate them statically at build-time so they can get cached.  And/or, I'll have to add requirejs to the service worker, which I'd like to avoid.