### PR TITLE
Changes corresponding to thimble issue #2378 (PDF Viewer Localization)

### DIFF
--- a/locales/en-US/editor.properties
+++ b/locales/en-US/editor.properties
@@ -202,6 +202,9 @@ BINARY_FILE_DOWNLOAD=Download it
 BINARY_FILE_OPEN=Open it in a new tab
 BINARY_FILE_TRY_EDIT=Try to edit it
 
+#PDF Viewer
+PDF_FILE_TITLE=PDF File
+
 ################
 ## EXTENSIONS ##
 ################

--- a/src/extensions/extra/PDFView/PDFView.js
+++ b/src/extensions/extra/PDFView/PDFView.js
@@ -27,6 +27,7 @@ define(function (require, exports, module) {
     var UrlCache            = brackets.getModule("filesystem/impls/filer/UrlCache"),
         Mustache            = brackets.getModule("thirdparty/mustache/mustache"),
         StringUtils         = brackets.getModule("utils/StringUtils"),
+        Strings             = brackets.getModule("strings"),
         ThemePrefs          = brackets
                               .getModule("preferences/PreferencesManager")
                               .getExtensionPrefs("themes"),
@@ -76,7 +77,8 @@ define(function (require, exports, module) {
                 pdfUrl: encodeURIComponent(UrlCache.getUrl(file.fullPath)),
                 locale: brackets.getLocale(),
                 fileSize: fileSize,
-                theme: ThemePrefs.get("theme")
+                theme: ThemePrefs.get("theme"),
+                fileTitle: Strings.PDF_FILE_TITLE
             }));
             $container.append(self.$el);
 

--- a/src/extensions/extra/PDFView/bramble-pdfjs.js
+++ b/src/extensions/extra/PDFView/bramble-pdfjs.js
@@ -6,7 +6,8 @@
     var fileSize = iframe.dataset.fileSize;
     // Theme will be one of "dark-theme" or "light-theme"
     var theme = iframe.dataset.theme;
-
+    
+    var fileTitle = iframe.dataset.fileTitle;
     /**
      * XXXBramble: PDF viewer doesn't allow passing locales by default for security reasons:
      * https://github.com/mozilla/pdf.js/issues/7432, so we are doing something like what
@@ -36,6 +37,7 @@
         document.querySelector("body").classList.add(theme);
         document.querySelector("#pdf-page-count").innerHTML = pagesCount;
         document.querySelector("#pdf-file-size").innerHTML = fileSize;
+        document.querySelector(".file-type").innerHTML = fileTitle;
     }
 
     // Wait for PDFViewerApplication.eventBus to get loaded and become available

--- a/src/extensions/extra/PDFView/htmlContent/pdf-view.html
+++ b/src/extensions/extra/PDFView/htmlContent/pdf-view.html
@@ -2,5 +2,6 @@
     class="pdf-view"
     src="extensions/extra/PDFView/htmlContent/viewer.html?file={{pdfUrl}}&locale={{locale}}"
     data-file-size="{{fileSize}}"
-    data-theme="{{theme}}">
+    data-theme="{{theme}}"
+    data-file-title="{{fileTitle}}">
 </iframe>

--- a/src/extensions/extra/PDFView/htmlContent/viewer.html
+++ b/src/extensions/extra/PDFView/htmlContent/viewer.html
@@ -254,7 +254,7 @@ See https://github.com/adobe-type-tools/cmap-resources
         <div id="viewerContainer" tabindex="0">
           <div class="header-wrapper">
             <p id="pdf-meta" class="viewer-header">
-              <span class="file-type">PDF</span>
+              <span class="file-type"></span>
               <span class="file-details">
                   <span id="pdf-page-count">&nbsp;</span> <span class="divider">&bull;</span> <span id="pdf-file-size">&nbsp;</span></p>
               </span>


### PR DESCRIPTION
Updated PDF viewer title to say "PDF File"
According to instructions provided by @flukeout in issue , I made the following changes - 
Added a PDF_FILE_TITLE=PDF File in locales/en-US/editor.properties.
Imported Strings module in PDFView.js and passed Strings.PDF_FILE_TITLE as fileTitle to Mustache rendering.
Added a data-file-title attribute in pdf-view.html .
Updated UI in bramble-pdfjs.js by setting the PDF viewer title to string passed. 