### PR TITLE
Fix #2372: Fix margins around project size panel

### DIFF
--- a/src/extensions/default/bramble/stylesheets/sidebarTheme.less
+++ b/src/extensions/default/bramble/stylesheets/sidebarTheme.less
@@ -36,7 +36,7 @@ div.working-set-option-btn[style] {
 
 // Indicates used and available room in a project
 #project-size-info {
-    padding: 12px 10px;
+    padding: 12px 10px 24px;
     transition: opacity .2s ease-out;
     overflow: hidden;
 


### PR DESCRIPTION
Fixes mozilla/thimble.mozilla.org#2372

I have simply added enough padding-bottom to be able to see correctly the size on the major desktop browsers I'm able to check (Chrome, FF, IE, Opera). I think is a better solution than just adjusting for everyone of the browser (saving lot of css for browser queries).

Attached is a screenshot from Chrome after the bugfix.

![image](https://user-images.githubusercontent.com/16190353/30672600-c1a2324c-9e6d-11e7-9277-03a74382ed0c.png)
