### PR TITLE
Unneeded gap where project size is displayed - thimble.mozilla.org #2505

### DIFF
--- a/src/extensions/default/bramble/stylesheets/sidebarTheme.less
+++ b/src/extensions/default/bramble/stylesheets/sidebarTheme.less
@@ -37,11 +37,10 @@ div.working-set-option-btn[style] {
 // Indicates used and available room in a project
 #project-size-info {
     padding: 12px 10px 24px;
-    transition: opacity .2s ease-out;
     overflow: hidden;
 
     &.hidden {
-        opacity: 0;
+        display: none;
     }
 
     .space-available {


### PR DESCRIPTION
This addresses https://github.com/mozilla/thimble.mozilla.org/issues/2505

- removed opacity transition 
- changed the display to `display: none;` so that the project size container won't take up space in the layout anymore.

@flukeout can you please review?