### PR TITLE
Fix for thimble.mozilla.org#2237

### DIFF
--- a/src/extensions/default/bramble/lib/RemoteEvents.js
+++ b/src/extensions/default/bramble/lib/RemoteEvents.js
@@ -32,10 +32,7 @@ define(function (require, exports, module) {
         });
     }
 
-    function sendActiveEditorChangeEvent(file) {
-        var fullPath = file.fullPath;
-        var filename = Path.basename(fullPath);
-
+    function sendActiveEditorChangeEvent(fullPath, filename) {
         sendEvent({
             type: "bramble:activeEditorChange",
             fullPath: fullPath,
@@ -98,27 +95,27 @@ define(function (require, exports, module) {
         var lastKnownEditorFilePath;
         MainViewManager.on("currentFileChange", function(e, file) {
             if(!file) {
-                // This happens when the last file in working set is deleted.
                 lastKnownEditorFilePath = "";
-                let noFile = {
-                    fullPath: "No File",
-                    filename: "No File"
-                };
-                sendActiveEditorChangeEvent(noFile);               
+                sendActiveEditorChangeEvent("", "");
                 return;
             }
 
-            if(file.fullPath !== lastKnownEditorFilePath) {
-                lastKnownEditorFilePath = file.fullPath;
-                sendActiveEditorChangeEvent(file);
+            var fullPath = file.fullPath;
+            var filename = Path.basename(fullPath);
+
+            if(fullPath !== lastKnownEditorFilePath) {
+                lastKnownEditorFilePath = fullPath;
+                sendActiveEditorChangeEvent(fullPath, filename);
             }
         });
 
         // Listen for file rename
         BrambleEvents.on("fileRenamed", function(e, oldFilePath, newFilePath) {
             if (oldFilePath === lastKnownEditorFilePath) {
-                lastKnownEditorFilePath = newFilePath;
-                sendActiveEditorChangeEvent({ fullPath: newFilePath });
+                var fullPath = newFilePath;
+                var filename = Path.basename(fullPath);
+                lastKnownEditorFilePath = fullPath;
+                sendActiveEditorChangeEvent(fullPath, filename);
             }
         });
 

--- a/src/extensions/default/bramble/lib/RemoteEvents.js
+++ b/src/extensions/default/bramble/lib/RemoteEvents.js
@@ -98,6 +98,13 @@ define(function (require, exports, module) {
         var lastKnownEditorFilePath;
         MainViewManager.on("currentFileChange", function(e, file) {
             if(!file) {
+                // This happens when the last file in working set is deleted.
+                lastKnownEditorFilePath = "";
+                let noFile = {
+                    fullPath: "No File",
+                    filename: "No File"
+                };
+                sendActiveEditorChangeEvent(noFile);               
                 return;
             }
 

--- a/src/extensions/default/bramble/stylesheets/sidebarTheme.less
+++ b/src/extensions/default/bramble/stylesheets/sidebarTheme.less
@@ -36,7 +36,7 @@ div.working-set-option-btn[style] {
 
 // Indicates used and available room in a project
 #project-size-info {
-    padding: 12px 10px;
+    padding: 12px 10px 24px;
     transition: opacity .2s ease-out;
     overflow: hidden;
 


### PR DESCRIPTION
Fixed mozilla/thimble.mozilla.org#2237 - "After deleting a file, it's name is still indicated in the Editor header bar."
Earlier, when last file was deleted, it was returning from the function without calling on the editor change event.
Right now, I have added a workaround for this, by sending an object with filename as "No File" which gets set in editor-nav-pane.