### PR TITLE
Added Math.log10 polyfill for IE11 support.

### DIFF
--- a/src/utils/Compatibility.js
+++ b/src/utils/Compatibility.js
@@ -34,6 +34,11 @@ define(function (require, exports, module) {
     if (!String.prototype.trimLeft) {
         String.prototype.trimLeft = function () { return this.replace(/^\s+/, ""); };
     }
+    
+    // Support for Math.log10 [IE11]
+    Math.log10 = Math.log10 || function(x) {
+        return Math.log(x) * Math.LOG10E;
+    };
 
     // [IE] Number.isFinite() is missing
     Number.isFinite = Number.isFinite || function(value) {


### PR DESCRIPTION
Issue:
`src/filesystem/impls/filer/lib/Sizes.js:48:        var exponent = Math.min(Math.floor(Math.log10(num) / 3), UNITS.length - 1);`
IE11 currently does not support Math.log10:

![mozilla docs](https://i.imgur.com/zECULjl.png)

So the solution for it according to the mozilla documents is to add the polyfill.