### PR TITLE
Fix mozilla/thimble.mozilla.org#2445: Added line numbers to console output

### DIFF
--- a/src/extensions/default/bramble/htmlContent/console.html
+++ b/src/extensions/default/bramble/htmlContent/console.html
@@ -5,6 +5,7 @@
         <button title="{{CONSOLE_CLOSE_TOOLTIP}}"href="#" class="close"></button>
     </div>
     <div class="console">
+      <div class="lines"></div>
       <div class="helper">
         <span class="helper-text">{{&CONSOLE_HELPTEXT}}</span>
       </div>

--- a/src/extensions/default/bramble/lib/ConsoleInterfaceManager.js
+++ b/src/extensions/default/bramble/lib/ConsoleInterfaceManager.js
@@ -42,10 +42,11 @@ define(function (require, exports, module) {
         wasClosedByUser = false,
         unreadCount = 0,
         consoleEl = null,
+        linesEl = null,        
         maxLogs = 30;
 
     function clear() {
-        consoleEl.find(".log-entry").remove();
+        linesEl.find("div").remove();
         unreadCount = 0;
     }
 
@@ -64,7 +65,9 @@ define(function (require, exports, module) {
     }
 
     function addLine(type, item) {
-        var $element = $("<div class='log-entry " + type + "'></div>");
+        var $lineElement = $("<div class='line'><div class='linenumber'></div><div class='log-entry " + type + "'></div></div>");
+        var $lineNumber = $lineElement.find(".linenumber");
+        var $lineEntry = $lineElement.find(".log-entry");
 
         if(typeof item === "object") {
           item = JSON.stringify(item);
@@ -75,20 +78,28 @@ define(function (require, exports, module) {
 
         if(!item.length) {
           item = Strings.CONSOLE_EMPTY_STRING;
-          $element.addClass("empty-string");
+          $lineElement.find(".log-entry").addClass("empty-string");
         }
 
-        $element.text(item);
-
+        $lineEntry.text(item);
+        
         if(panel.isVisible()) {
-          $element.addClass("new-log");
+            $lineElement.find(".log-entry").addClass("new-log");
         }
 
-        consoleEl.append($element);
+        //Add a line number to the new entry
+        if(linesEl.find(".line").length === 0){
+            $lineNumber.html(1);
+        }else{
+            var lastLineNum = linesEl.children().last().children(".linenumber").html();  
+            $lineNumber.html(parseInt(lastLineNum) + 1);            
+        }
 
-        var logCount = consoleEl.find("div").length;
+        linesEl.append($lineElement);
+
+        var logCount = linesEl.find(".line").length;
         if(logCount > maxLogs) {
-          consoleEl.find(":first-child").remove();
+            linesEl.children(".line:first").remove();
         }
 
         consoleEl.animate({ scrollTop: consoleEl[0].scrollHeight }, 10);
@@ -136,6 +147,7 @@ define(function (require, exports, module) {
         showConsoleTab.appendTo($("#editor-holder"));
 
         consoleEl = panel.$panel.find(".console");
+        linesEl = panel.$panel.find(".lines");        
 
         panel.$panel.find("#clearConsole").on("click", function () {
             clear();

--- a/src/extensions/default/bramble/stylesheets/consoleTheme.less
+++ b/src/extensions/default/bramble/stylesheets/consoleTheme.less
@@ -17,13 +17,39 @@
     border: 0;
     outline: none;
     box-shadow: none;
-    display: block;
+    display: inline-block;
     font-size: 15px;
     font-family: 'Menlo Regular', Consolas, Inconsolata, 'Vera Sans', 'Lucida Console', Courier, monospace, fixed;
     user-select: text;
     color: black;
     transform-origin: 15% 50%;
     white-space: pre-line;
+}
+
+#editor-console .console .lines {
+    background: none;
+    border: 0;
+}
+
+#editor-console .console .lines .line{
+    display: flex;
+}
+
+#editor-console .console .lines .line .linenumber {
+    width: 35px;
+    padding: 6px 0px;
+    font-size: 15px;
+    text-align: right;
+    display: inline-block;    
+    color: #CCCCCC;
+    font-family: "Menlo Regular", Consolas, Inconsolata, "Vera Sans", "Lucida Console", Courier, monospace, fixed;
+    animation: newLogFlash 1.5s ease-out, consolePop .2s ease-out;    
+    top: 0px;
+    bottom: 0px;
+}
+
+.dark #editor-console .console .lines .line .linenumber {
+    color: #656565;
 }
 
 #editor-console .console .helper {


### PR DESCRIPTION
This fixes mozilla/thimble.mozilla.org#2445.

@flukeout, @humphd 
This PR adds line numbers to the console's output windows. I kept the original line spacing of the output window for consistency.

Here's a quick example of how it looks in action:
![ezgif-5-f915db4f86](https://user-images.githubusercontent.com/16764878/31634817-b8e4a728-b292-11e7-8487-671e635382c0.gif)
