### PR TITLE
Fix for mozilla/thimble.mozilla.org#2111

### DIFF
--- a/src/extensions/default/bramble/stylesheets/sidebarTheme.less
+++ b/src/extensions/default/bramble/stylesheets/sidebarTheme.less
@@ -433,6 +433,9 @@ body[data-theme='light-theme'] li.jstree-leaf a.selected-node:hover {
     }
     font-size: 15px;
     line-height: 15px;
+    @-moz-document url-prefix() {
+        line-height: 20px;
+    }
     background: white;
     top: 0 !important;
     display: block;


### PR DESCRIPTION
Fix for mozilla/thimble.mozilla.org#2111 

When renaming the file in Firefox, the text should no longer be clipped.
Before -> After
![old](https://user-images.githubusercontent.com/22038681/31639773-7d14a818-b2a8-11e7-9cb7-ee945c378e90.png)
![new](https://user-images.githubusercontent.com/22038681/31639772-7d00e63e-b2a8-11e7-83c0-239ce2caef0f.png)
