### PR TITLE
Fix mozilla/thimble.mozilla.org#2515: QuickEdit Lightning indicator now disappears when switching to Font Viewer

### DIFF
--- a/src/editor/PopoverWidget.js
+++ b/src/editor/PopoverWidget.js
@@ -180,7 +180,6 @@ define(function (require, exports, module) {
 
         var editorHolder = $("#editor-holder")[0];
         editorHolder.addEventListener("scroll", handleScroll, true);
-        
     });
 
     // Create the preview container

--- a/src/editor/PopoverWidget.js
+++ b/src/editor/PopoverWidget.js
@@ -178,6 +178,7 @@ define(function (require, exports, module) {
 
         var editorHolder = $("#editor-holder")[0];
         editorHolder.addEventListener("scroll", handleScroll, true);
+        EditorManager.on("activeEditorChange", onActiveEditorChange);
     });
 
     // Create the preview container

--- a/src/editor/PopoverWidget.js
+++ b/src/editor/PopoverWidget.js
@@ -176,9 +176,11 @@ define(function (require, exports, module) {
             hidePopover();
         }
 
+        EditorManager.on("activeEditorChange", onActiveEditorChange);
+
         var editorHolder = $("#editor-holder")[0];
         editorHolder.addEventListener("scroll", handleScroll, true);
-        EditorManager.on("activeEditorChange", onActiveEditorChange);
+        
     });
 
     // Create the preview container


### PR DESCRIPTION
Fix for [mozilla/thimble.mozilla.org#2515](https://github.com/mozilla/thimble.mozilla.org/issues/2515)

When switching to the Font Viewer while adding/editing a CSS color rule, the indicator should now disappear.

Before:
![bug2515before](https://user-images.githubusercontent.com/32388517/31680506-81f18884-b342-11e7-88e4-c155b647b0bc.gif)

After:
![bug2515fixed](https://user-images.githubusercontent.com/32388517/31680527-8c0ebfbc-b342-11e7-8202-53c2ddf2e351.gif)
