### PR TITLE
Fallback to cacheType=blob automatically when service worker registration fails.

### DIFF
--- a/src/filesystem/impls/filer/UrlCache.js
+++ b/src/filesystem/impls/filer/UrlCache.js
@@ -342,6 +342,14 @@ define(function (require, exports, module) {
 
 
     function init(callback) {
+        // In the case of a failed service worker installation (often Firefox),
+        // we signal that Blob URLs should get used via `window.brambleCacheType`
+        // see src/main.js.
+        if (window.brambleCacheType === 'blob') {
+            _provider = new BlobUrlProvider();
+            return _provider.init(callback);
+        }
+
         // Allow overriding the cache type via cacheType=blob or cacheType=cacheStorage
         var cacheTypeOverride = getCacheType();
         switch(cacheTypeOverride) {

--- a/src/main.js
+++ b/src/main.js
@@ -126,7 +126,10 @@ if ('serviceWorker' in window.navigator) {
         };
     }).catch(function (e) {
         "use strict";
-        console.error('[Bramble] Error during service worker registration:', e);
+        console.warn('[Bramble] Error during service worker registration:', e);
+
+        console.log('[Bramble] Falling back to cachType=blob due to failed service worker');
+        window.brambleCacheType = 'blob';
     });
 }
 


### PR DESCRIPTION
This does an automatic failover for Blob URLs when Service Worker registration fails.  See https://twitter.com/wanderview/status/930920183643934727, though there could be other reasons it might fail.

We need to test this the third-party cookies on and off in Firefox.  When we failover, it should spit out a bunch of new console logs indicating that.