### PR TITLE
Fix mozilla/thimble.mozilla.org#2563

### DIFF
--- a/src/bramble/client/main.js
+++ b/src/bramble/client/main.js
@@ -122,33 +122,18 @@ define([
 
     // Expose Filer for Path, Buffer, providers, etc.
     Bramble.Filer = Filer;
+
     var _fs;
+    var useTemporaryStorage = location.search === "?BrambleMemoryFileSystem";
+    var provider = null;
 
-    // Set URL param for memory-backed FileSystem
-    var mem_filesystem = "BrambleMemoryFileSystem";
-
-    // Splits the parameter from the URL
-    function getUrlParams() {
-      var param = decodeURIComponent( window.location.href.slice( window.location.href.indexOf( '?' ) + 1 ) );
-      return param;
+    // [Bramble] Overriding filesystem to use temporary storage. ALL FILES WILL BE DELETED WHEN PAGE IS CLOSED.
+    if(useTemporaryStorage) {
+      provider = new Filer.FileSystem.providers.Memory();
+      console.warn("Using memory-backed filesystem");
     }
 
-    // Check if the parameter is equal to 'BrambleMemoryFileSystem'
-    if(getUrlParams() === mem_filesystem) {
-      console.log("Using memory-backed filesystem");
-      // Memory backed fs
-      _fs = new Filer.FileSystem({
-        flags: [ 'FORMAT' ],
-        provider: new Filer.FileSystem.providers.Memory()
-      });
-    } else {
-      console.log("Using indexDB backed filesystem");
-      // Default IndexedDB backed fs
-      _fs = new Filer.FileSystem({
-        flags: [ 'FORMAT' ],
-        provider: new Filer.FileSystem.providers.IndexedDB()
-      });
-    }
+    _fs = new Filer.FileSystem({provider : provider});
 
     Bramble.getFileSystem = function() {
         return _fs;
@@ -156,7 +141,7 @@ define([
 
     // NOTE: THIS WILL DESTROY DATA! For error cases only, or to wipe the disk.
     Bramble.formatFileSystem = function(callback) {
-        _fs = new Filer.FileSystem({flags: ["FORMAT"]}, function(err) {
+        _fs = new Filer.FileSystem({flags: ["FORMAT"], provider : provider}, function(err) {
             if(err) {
                 return callback(err);
             }

--- a/src/bramble/client/main.js
+++ b/src/bramble/client/main.js
@@ -122,7 +122,34 @@ define([
 
     // Expose Filer for Path, Buffer, providers, etc.
     Bramble.Filer = Filer;
-    var _fs = new Filer.FileSystem();
+    var _fs;
+
+    // Set URL param for memory-backed FileSystem
+    var mem_filesystem = "BrambleMemoryFileSystem";
+
+    // Splits the parameter from the URL
+    function getUrlParams() {
+      var param = decodeURIComponent( window.location.href.slice( window.location.href.indexOf( '?' ) + 1 ) );
+      return param;
+    }
+
+    // Check if the parameter is equal to 'BrambleMemoryFileSystem'
+    if(getUrlParams() == mem_filesystem) {
+      console.log("Using memory-backed filesystem")
+      // Memory backed fs
+      _fs = new Filer.FileSystem({
+        flags: [ 'FORMAT' ],
+        provider: new Filer.FileSystem.providers.Memory()
+      });
+    } else {
+      console.log("Using indexDB backed filesystem")  
+      // Default IndexedDB backed fs
+      _fs = new Filer.FileSystem({
+        flags: [ 'FORMAT' ],
+        provider: new Filer.FileSystem.providers.IndexedDB()
+      });
+    }
+
     Bramble.getFileSystem = function() {
         return _fs;
     };

--- a/src/bramble/client/main.js
+++ b/src/bramble/client/main.js
@@ -134,15 +134,15 @@ define([
     }
 
     // Check if the parameter is equal to 'BrambleMemoryFileSystem'
-    if(getUrlParams() == mem_filesystem) {
-      console.log("Using memory-backed filesystem")
+    if(getUrlParams() === mem_filesystem) {
+      console.log("Using memory-backed filesystem");
       // Memory backed fs
       _fs = new Filer.FileSystem({
         flags: [ 'FORMAT' ],
         provider: new Filer.FileSystem.providers.Memory()
       });
     } else {
-      console.log("Using indexDB backed filesystem")  
+      console.log("Using indexDB backed filesystem");
       // Default IndexedDB backed fs
       _fs = new Filer.FileSystem({
         flags: [ 'FORMAT' ],

--- a/src/bramble/client/main.js
+++ b/src/bramble/client/main.js
@@ -131,8 +131,8 @@ define([
 
     // Using memory-backed filesystem if requested
     if(useTemporaryStorage) {
-      provider = new Filer.FileSystem.providers.Memory();
-      console.warn("[Bramble] Overriding filesystem to use temporary storage. ALL FILES WILL BE DELETED WHEN PAGE IS CLOSED.");
+        provider = new Filer.FileSystem.providers.Memory();
+        console.warn("[Bramble] Overriding filesystem to use temporary storage. ALL FILES WILL BE DELETED WHEN PAGE IS CLOSED.");
     }
 
     _fs = new Filer.FileSystem({provider : provider});

--- a/src/bramble/client/main.js
+++ b/src/bramble/client/main.js
@@ -129,10 +129,10 @@ define([
     var useTemporaryStorage = /(temporary[sS]torage[=&])|(temporary[Ss]torage$)/.test(window.location.search);
     var provider = null;
 
-    // [Bramble] Overriding filesystem to use temporary storage. ALL FILES WILL BE DELETED WHEN PAGE IS CLOSED.
+    // Using memory-backed filesystem if requested
     if(useTemporaryStorage) {
       provider = new Filer.FileSystem.providers.Memory();
-      console.warn("Using memory-backed filesystem");
+      console.warn("[Bramble] Overriding filesystem to use temporary storage. ALL FILES WILL BE DELETED WHEN PAGE IS CLOSED.");
     }
 
     _fs = new Filer.FileSystem({provider : provider});

--- a/src/bramble/client/main.js
+++ b/src/bramble/client/main.js
@@ -124,7 +124,9 @@ define([
     Bramble.Filer = Filer;
 
     var _fs;
-    var useTemporaryStorage = location.search === "?BrambleMemoryFileSystem";
+
+    // Checks if the query parameter is 'temporaryStorage'
+    var useTemporaryStorage = /(temporary[sS]torage[=&])|(temporary[Ss]torage$)/.test(window.location.search);
     var provider = null;
 
     // [Bramble] Overriding filesystem to use temporary storage. ALL FILES WILL BE DELETED WHEN PAGE IS CLOSED.


### PR DESCRIPTION
This code checks for the 'BrambleMemoryFileSystem' parameter in the URL. When the parameter is given the memory-backed filesystem is used instead of the indexedDB filesystem. 