### PR TITLE
Adds extra space above & below inline widgets.

### DIFF
--- a/src/styles/brackets.less
+++ b/src/styles/brackets.less
@@ -1112,13 +1112,16 @@ a, img {
     position: relative;
     overflow: hidden;
     outline: none;
-
+    border-top: solid 8px white;
+    border-bottom: solid 8px white;
     background-color: @bc-bg-inline-widget;
     min-width: 250px;
     cursor: default;
 
     .dark & {
         background-color: @dark-bc-bg-inline-widget;
+        border-top: solid 8px #222;
+        border-bottom: solid 8px #222;
     }
 
     &.animating {


### PR DESCRIPTION
This is a small change that adds a bit of breathing space above and below inline widgets.

Currently, the widget edge sits right up against the line of code above it. The highlight around the value that is being changed actually touches the widget border, which looks lame and busy...

![image](https://user-images.githubusercontent.com/25212/33502572-80e2207c-d695-11e7-9bf3-b8d96c43e6c0.png)

This small change adds a bit of breathing room...

![image](https://user-images.githubusercontent.com/25212/33502618-a4e5313a-d695-11e7-82cb-92407cc7ad0f.png)



