### PR TITLE
Updated grunt test task to run linting only

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ node_js:
   - "6"
 before_script:
 - npm install -g grunt-cli
-script: grunt build-browser-compressed
 branches:
   only:
   - master
@@ -21,6 +20,8 @@ addons:
       - ubuntu-toolchain-r-test
     packages:
       - g++-4.8
+before_deploy:
+- npm run preproduction
 deploy:
   - provider: s3
     access_key_id: AKIAI7XHSZFYVHFRTRIA

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,6 @@ language: node_js
 sudo: false # use container-based Travis infrastructure
 node_js:
   - "6"
-before_script:
-- npm install -g grunt-cli
 branches:
   only:
   - master

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -538,7 +538,7 @@ module.exports = function (grunt) {
     grunt.registerTask('install', ['write-config', 'less', 'npm-install-source']);
 
     // task: test
-    grunt.registerTask('test', ['eslint', 'jasmine', 'nls-check']);
+    grunt.registerTask('test', ['eslint']);
 //    grunt.registerTask('test', ['eslint', 'jasmine', 'jasmine_node', 'nls-check']);
 
     // task: set-release

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -539,7 +539,6 @@ module.exports = function (grunt) {
 
     // task: test
     grunt.registerTask('test', ['eslint']);
-//    grunt.registerTask('test', ['eslint', 'jasmine', 'jasmine_node', 'nls-check']);
 
     // task: set-release
     // Update version number in package.json and rewrite src/config.json

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
         "build": "grunt build-browser",
         "preproduction": "grunt build-browser-compressed && npm run unlocalize",
         "production": "npm start -- --gzip",
-        "test": "grunt test && grunt build-browser-compressed",
+        "test": "grunt test",
         "server": "http-server -p 8000 --cors",
         "prestart": "npm run localize && grunt build-browser-dev",
         "start": "npm run server || true",


### PR DESCRIPTION
Removed 'jasmine' and 'nls-check' from grunt test task so that it only tests for linting.  Also removed `grunt build-browser-compressed` from `npm test`. In `.travis.yml` the `npm run preproduction` command is used to generate the `dist` folder and the built files inside it, before deploying to Amazon S3.

This fix addresses the bug issue 2572 from the Thimble repo. Link to the issue: 

Fix mozilla/thimble.mozilla.org#2572