### PR TITLE
Fix #2574 thimble.mozilla.org - Autocomplete Suggestions UI Styling

### DIFF
--- a/src/extensions/extra/JavaScriptCodeHints-Browser/styles/brackets-js-hints.css
+++ b/src/extensions/extra/JavaScriptCodeHints-Browser/styles/brackets-js-hints.css
@@ -167,7 +167,6 @@ span.brackets-js-hints-with-type-details {
     box-sizing: border-box;
     float: left;
     clear: left;
-    max-height: 3em;
     overflow: hidden;
 }
 


### PR DESCRIPTION
![Result](https://user-images.githubusercontent.com/10699431/33941110-176ffebe-e01a-11e7-9132-914414a70f3e.gif)

- max-height jshint-jsdoc's class property removed.

Read this issue for more info
https://github.com/mozilla/thimble.mozilla.org/issues/2574