### PR TITLE
Google Import Not Used

### DIFF
--- a/src/styles/brackets_fonts.less
+++ b/src/styles/brackets_fonts.less
@@ -18,9 +18,6 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
 // DEALINGS IN THE SOFTWARE.
 
-/* Bramble Font - https://www.google.com/fonts/specimen/Inconsolata */
-@import url(https://fonts.googleapis.com/css?family=Inconsolata);
-
 /* Brackets Fonts */
 
 /* Alternative weights */


### PR DESCRIPTION
Fixing a bug that was issued in Thimble: 2343. This was an unnecessary import statement as the fonts imported are not used