### PR TITLE
Fix #2307 Add support for auto downsizing non-animated GIFs with Imag…

### DIFF
--- a/src/filesystem/impls/filer/FilerFileSystem.js
+++ b/src/filesystem/impls/filer/FilerFileSystem.js
@@ -303,7 +303,7 @@ define(function (require, exports, module) {
                     }
 
                     // If this is a big image (>250K), resize it first
-                    if(Content.isResizableImage(ext) && Content.isImageTooLarge(data.length)) {
+                    if(Content.isResizableImage(ext) && !Content.isAnimated(data) && Content.isImageTooLarge(data.length)) {
                         ImageResizer.resize(path, data, function(err, resized) {
                             if(err) {
                                 return callback(err);

--- a/src/filesystem/impls/filer/lib/content.js
+++ b/src/filesystem/impls/filer/lib/content.js
@@ -9,6 +9,7 @@ define(function (require, exports, module) {
     var Strings = require("strings");
     var StringUtils = require("utils/StringUtils");
     var FilerUtils = require('filesystem/impls/filer/FilerUtils');
+    var isAnimated = require("isAnimated");
     var Path = FilerUtils.Path;
 
     function _getLanguageId(ext) {
@@ -140,7 +141,11 @@ define(function (require, exports, module) {
 
         isResizableImage: function(ext) {
             ext = FilerUtils.normalizeExtension(ext);
-            return ext === '.png' || ext === '.jpg' || ext === '.jpeg';
+            return ext === '.png' || ext === '.jpg' || ext === '.jpeg' || ext === '.gif';
+        },
+
+        isAnimatedImage: function(data) {            
+            return isAnimated(data);
         },
 
         isHTML: function(ext) {

--- a/src/main.js
+++ b/src/main.js
@@ -40,6 +40,7 @@ require.config({
         // Image processing libraries
         "Pica": "../node_modules/pica/dist/pica.min",
         "caman": "thirdparty/caman/caman.full.min",
+        "isAnimated": "thirdparty/is-animated/lib/index",
 
         // In various places in the code, it's useful to know if this is a dev vs. prod env.
         // See Gruntfile for prod override of this to config.prod.js.
@@ -54,6 +55,9 @@ require.config({
     shim: {
         "caman": {
             exports: "Caman"
+        },
+        "isAnimated": {
+            exports: "isAnimated"
         }
     }
 });

--- a/src/thirdparty/is-animated/LICENSE.md
+++ b/src/thirdparty/is-animated/LICENSE.md
@@ -1,0 +1,9 @@
+# [MIT License](https://spdx.org/licenses/MIT)
+
+Copyright (c) 2016 Józef Sokołowski <j.k.sokolowski@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/src/thirdparty/is-animated/lib/index.js
+++ b/src/thirdparty/is-animated/lib/index.js
@@ -1,0 +1,26 @@
+define(function (require, exports, module) {
+  'use strict';
+  
+  var gif = require('thirdparty/is-animated/lib/types/gif');
+  var png = require('thirdparty/is-animated/lib/types/png');
+  
+  /**
+   * Checks if buffer contains animated image
+   *
+   * @param {Buffer} buffer
+   * @returns {boolean}
+   */
+  function isAnimated (buffer) {
+    if (gif.isGIF(buffer)) {
+      return gif.isAnimated(buffer);
+    }
+  
+    if (png.isPNG(buffer)) {
+      return png.isAnimated(buffer);
+    }
+  
+    return false;
+  }
+  
+  module.exports = isAnimated;
+});

--- a/src/thirdparty/is-animated/lib/types/gif.js
+++ b/src/thirdparty/is-animated/lib/types/gif.js
@@ -1,0 +1,103 @@
+define(function (require, exports, module) {
+  'use strict';
+  
+  /**
+   * Returns total length of data blocks sequence
+   *
+   * @param {Buffer} buffer
+   * @param {number} offset
+   * @returns {number}
+   */
+  function getDataBlocksLength (buffer, offset) {
+    var length = 0;
+  
+    while (buffer[offset + length]) {
+      length += buffer[offset + length] + 1;
+    }
+  
+    return length + 1;
+  }
+  
+  /**
+   * Checks if buffer contains GIF image
+   *
+   * @param {Buffer} buffer
+   * @returns {boolean}
+   */
+  exports.isGIF = function (buffer) {
+    var header = buffer.slice(0, 3).toString('ascii');
+    return (header === 'GIF');
+  };
+  
+  /**
+   * Checks if buffer contains animated GIF image
+   *
+   * @param {Buffer} buffer
+   * @returns {boolean}
+   */
+  exports.isAnimated = function (buffer) {
+    var hasColorTable, colorTableSize, header;
+    var offset = 0;
+    var imagesCount = 0;
+  
+    // Check if this is this image has valid GIF header.
+    // If not return false. Chrome, FF and IE doesn't handle GIFs with invalid version.
+    header = buffer.slice(0, 3).toString('ascii');
+  
+    if (header !== 'GIF') {
+      return false;
+    }
+  
+    // Skip header, logical screen descriptor and global color table
+  
+    hasColorTable = buffer[10] & 0x80; // 0b10000000
+    colorTableSize = buffer[10] & 0x07; // 0b00000111
+  
+    offset += 6;                                                              // skip header
+    offset += 7;                                                              // skip logical screen descriptor
+    offset += hasColorTable ? 3 * Math.pow(2, colorTableSize + 1) : 0;        // skip global color table
+  
+    // Find if there is more than one image descriptor
+  
+    while (imagesCount < 2 && offset < buffer.length) {
+      switch (buffer[offset]) {
+        // Image descriptor block. According to specification there could be any
+        // number of these blocks (even zero). When there is more than one image
+        // descriptor browsers will display animation (they shouldn't when there
+        // is no delays defined, but they do it anyway).
+        case 0x2C:
+          imagesCount += 1;
+  
+          hasColorTable = buffer[offset + 9] & 0x80; // 0b10000000
+          colorTableSize = buffer[offset + 9] & 0x07; // 0b00000111
+  
+          offset += 10;                                                       // skip image descriptor
+          offset += hasColorTable ? 3 * Math.pow(2, colorTableSize + 1) : 0;  // skip local color table
+          offset += getDataBlocksLength(buffer, offset + 1) + 1;              // skip image data
+  
+          break;
+  
+        // Skip all extension blocks. In theory this "plain text extension" blocks
+        // could be frames of animation, but no browser renders them.
+        case 0x21:
+          offset += 2;                                                        // skip introducer and label
+          offset += getDataBlocksLength(buffer, offset);                      // skip this block and following data blocks
+  
+          break;
+  
+        // Stop processing on trailer block,
+        // all data after this point will is ignored by decoders
+        case 0x3B:
+          offset = buffer.length;                                             // fast forward to end of buffer
+          break;
+  
+        // Oops! This GIF seems to be invalid
+        default:
+          offset = buffer.length;                                             // fast forward to end of buffer
+          break;
+      }
+    }
+  
+    return (imagesCount > 1);
+  };
+});

--- a/src/thirdparty/is-animated/lib/types/png.js
+++ b/src/thirdparty/is-animated/lib/types/png.js
@@ -1,0 +1,56 @@
+define(function (require, exports, module) {
+  'use strict';
+  exports.isPNG = function (buffer) {
+    var header = buffer.slice(0, 8).toString('hex');
+    return (header === '89504e470d0a1a0a'); // \211 P N G \r \n \032 'n
+  };
+  
+  exports.isAnimated = function (buffer) {
+    var hasACTL = false;
+    var hasIDAT = false;
+    var hasFDAT = false;
+  
+    var previousChunkType = null;
+  
+    var offset = 8;
+  
+    while (offset < buffer.length) {
+      var chunkLength = buffer.readUInt32BE(offset);
+      var chunkType = buffer.slice(offset + 4, offset + 8).toString('ascii');
+  
+      switch (chunkType) {
+        case 'acTL':
+          hasACTL = true;
+          break;
+        case 'IDAT':
+          if (!hasACTL) {
+            return false;
+          }
+  
+          if (previousChunkType !== 'fcTL') {
+            return false;
+          }
+  
+          hasIDAT = true;
+          break;
+        case 'fdAT':
+          if (!hasIDAT) {
+            return false;
+          }
+  
+          if (previousChunkType !== 'fcTL') {
+            return false;
+          }
+  
+          hasFDAT = true;
+          break;
+      }
+  
+      previousChunkType = chunkType;
+      offset += 4 + 4 + chunkLength + 4;
+    }
+  
+    return (hasACTL && hasIDAT && hasFDAT);
+  };
+
+});


### PR DESCRIPTION
The non-animated gif also got to be resized to around 250KB.

test file1// non-animated gif over 300KB-> around 250KB
![single](https://user-images.githubusercontent.com/22462471/34624833-a5a8302c-f224-11e7-8be5-c0b7c173b912.gif)

<img width="247" alt="snapcrab_noname_2018-1-5_10-56-34_no-00" src="https://user-images.githubusercontent.com/22462471/34624699-3c38c19c-f224-11e7-9940-757294b68182.png">

test file 2 // animated gif over 300KB-> keep original
![anime](https://user-images.githubusercontent.com/22462471/34624851-b2b961f0-f224-11e7-8394-4da1f04250b6.gif)

<img width="247" alt="snapcrab_noname_2018-1-5_10-56-21_no-00" src="https://user-images.githubusercontent.com/22462471/34624721-47c79f42-f224-11e7-97db-7a916b454bef.png">

test file 3 //  non-animated png over 500KB-> around 250KB
![single](https://user-images.githubusercontent.com/22462471/34965140-da7d4474-fa1f-11e7-9eaf-366511ed6c5e.png)

<img width="258" alt="snapcrab_noname_2018-1-15_17-34-39_no-00" src="https://user-images.githubusercontent.com/22462471/34965150-e699ab26-fa1f-11e7-9295-03c0c837bc13.png">

test file 4 // animated png(not move on IE) over 300KB-> keep original
![anime](https://user-images.githubusercontent.com/22462471/34964234-8d3c08e4-fa1a-11e7-83d9-2d52c92b79d1.png)

<img width="258" alt="snapcrab_noname_2018-1-15_17-34-27_no-00" src="https://user-images.githubusercontent.com/22462471/34964288-d6903a06-fa1a-11e7-9583-d18234f28056.png">


  