### PR TITLE
Fixed skew image - Issue 2113

### DIFF
--- a/src/extensions/default/BrambleUrlCodeHints/style.less
+++ b/src/extensions/default/BrambleUrlCodeHints/style.less
@@ -4,7 +4,7 @@
 
 #selfie-video {
     width: 320px;
-    height: 240px;
+    height: auto;
     background-color: black !important;
 }
 
@@ -97,7 +97,7 @@
 
 #selfie-video-bg {
     width: 320px;
-    height: 240px;
+    height: auto;
     background: white;
     position: absolute;
     opacity: 0;


### PR DESCRIPTION
Fixes mozilla/thimble.mozilla.org#2113 
Image skew is now removed from the Edge. Image height is set to auto now. The video will have a height of 180px in Edge but 240px in other browsers. The problem is the 'object-fit : cover' property does not works in edge due to which resizing the video height according to the browser seems a better option to me. 