### PR TITLE
Fixed inverted image preview - Issue 2593

### DIFF
--- a/src/extensions/default/BrambleUrlCodeHints/style.less
+++ b/src/extensions/default/BrambleUrlCodeHints/style.less
@@ -6,6 +6,10 @@
     width: 320px;
     height: auto;
     background-color: black !important;
+    -webkit-transform: rotateY(180deg); /* Safari and Chrome */
+    -moz-transform: rotateY(180deg); /* Firefox */
+    -o-transform: rotateY(180deg); /* Opera */
+    transform: rotateY(180deg);
 }
 
 #selfie-widget {


### PR DESCRIPTION
Fixes - mozilla/thimble.mozilla.org#2593
This PR fixes the preview image for selfie. The selfie image remains inverted (unchanged) as in various other apps but the preview of the image is fixed (not inverted) now.
