### PR TITLE
Fix Thimble 2599 - don't error on messages from browser extensions

### DIFF
--- a/src/LiveDevelopment/MultiBrowserImpl/protocol/remote/LiveDevProtocolRemote.js
+++ b/src/LiveDevelopment/MultiBrowserImpl/protocol/remote/LiveDevProtocolRemote.js
@@ -349,7 +349,7 @@
             try {
                 msg = JSON.parse(msgStr);
             } catch (e) {
-                console.log("[Brackets LiveDev] Malformed message received: ", msgStr);
+                // Ignore any message that isn't valid JSON (e.g., coming from an extension)
                 return;
             }
             // delegates handling/routing to MessageBroker.

--- a/src/extensions/default/bramble/lib/PostMessageTransport.js
+++ b/src/extensions/default/bramble/lib/PostMessageTransport.js
@@ -49,6 +49,10 @@ define(function (require, exports, module) {
     // ["blob://http://url"]}}` will be mapped into `{"stylesheets":
     // {"/file1" : ["/file1"]}}`
     function resolveLinks(message) {
+        if(!message) {
+            return;
+        }
+
         var regex = new RegExp('\\"(blob:[^"]+)\\"', 'gm');
         var resolvedMessage = message.replace(regex, function(match, url) {
             var path = UrlCache.getFilename(url);
@@ -142,6 +146,10 @@ define(function (require, exports, module) {
     *
     */
     function resolvePaths(message) {
+        if(!message) {
+            return;
+        }
+
         var currentDoc = LiveDevMultiBrowser._getCurrentLiveDoc();
         if(!currentDoc) {
             return message;

--- a/src/extensions/default/bramble/lib/RemoteCommandHandler.js
+++ b/src/extensions/default/bramble/lib/RemoteCommandHandler.js
@@ -240,7 +240,7 @@ define(function (require, exports, module) {
         try {
             remoteRequest = JSON.parse(e.data);
         } catch(err) {
-            console.log('[Bramble] unable to parse remote request:', e.data);
+            // Ignore any data that isn't JSON (e.g., coming from browser extension)
             return;
         }
 


### PR DESCRIPTION
Here's some initial work to do better when there are browser extensions sending messages to our frames over `postMessage`.  It tries to address https://github.com/mozilla/thimble.mozilla.org/issues/2599.

Later we could evolve things to use a `MessageChannel`, but that's a lot of work that I don't want to do if this will solve things.