### PR TITLE
Removed the Browser.setListener caller

### DIFF
--- a/src/extensions/default/bramble/lib/PostMessageTransport.js
+++ b/src/extensions/default/bramble/lib/PostMessageTransport.js
@@ -111,7 +111,7 @@ define(function (require, exports, module) {
             // Not one of our custom events, re-trigger message event to LiveDev
             module.exports.trigger("message", [connId, msgObj.message]);
         } else if (msgObj.type === "connect") {
-            Browser.setListener();
+            //Browser.setListener();
             // Make sure the correct mouse cursor is set, depending on inspector state.
             MouseManager.ensurePreviewCursor();
         }

--- a/src/extensions/default/bramble/lib/PostMessageTransport.js
+++ b/src/extensions/default/bramble/lib/PostMessageTransport.js
@@ -111,7 +111,7 @@ define(function (require, exports, module) {
             // Not one of our custom events, re-trigger message event to LiveDev
             module.exports.trigger("message", [connId, msgObj.message]);
         } else if (msgObj.type === "connect") {
-            //Browser.setListener();
+        
             // Make sure the correct mouse cursor is set, depending on inspector state.
             MouseManager.ensurePreviewCursor();
         }


### PR DESCRIPTION
Removed the Browser.setListener caller from https://github.com/mozilla/brackets/blob/master/src/extensions/default/bramble/lib/PostMessageTransport.js#L114

Related to issue: https://github.com/mozilla/thimble.mozilla.org/issues/2608