### PR TITLE
Fix fragment id links in preview

### DIFF
--- a/src/extensions/default/bramble/lib/LinkManagerRemote.js
+++ b/src/extensions/default/bramble/lib/LinkManagerRemote.js
@@ -45,7 +45,7 @@
             window.open(url, "_blank");
         }
 
-        return false;
+        e.preventDefault();
     }
 
     addEventListener("DOMContentLoaded", function init() {


### PR DESCRIPTION
My guess is that browsers used to handle this differently (explains why it might have worked before). Either way, in practice, `return false` won't work unless it's in an attribute event listener.

Opening a PR without review just in case I need to revert this change

Fix https://github.com/mozilla/thimble.mozilla.org/issues/2468