### PR TITLE
Adds Feature Policies enabling geolocation, microphone, camera on iframe

### DIFF
--- a/src/bramble/client/main.js
+++ b/src/bramble/client/main.js
@@ -478,7 +478,7 @@ define([
             }
 
             div.innerHTML = "<iframe id='" + _id +
-                            "' frameborder='0' width='100%' height='100%'></iframe>";
+                            "' frameborder='0' width='100%' height='100%' allow='geolocation *; microphone *; camera *'></iframe>";
 
             _iframe = document.getElementById(_id);
             if (options.hideUntilReady) {

--- a/src/extensions/default/bramble/lib/iframe-browser.js
+++ b/src/extensions/default/bramble/lib/iframe-browser.js
@@ -46,7 +46,7 @@ define(function (require, exports, module) {
             frameborder: 0
         };
         //Append iFrame to _panel
-        $("<iframe>", iframeConfig).addClass("iframeWidthHeight").appendTo(_panel);
+        $("<iframe>", iframeConfig).addClass("iframeWidthHeight").prop("allow", "geolocation *; microphone *; camera *").appendTo(_panel);
     }
 
     /*
@@ -122,7 +122,7 @@ define(function (require, exports, module) {
      */
     function hide() {
         Resizer.hide("#second-pane");
-        $("#first-pane").addClass("expandEditor");        
+        $("#first-pane").addClass("expandEditor");
     }
 
     /**
@@ -130,7 +130,7 @@ define(function (require, exports, module) {
      */
     function show() {
         Resizer.show("#second-pane");
-        $("#first-pane").removeClass("expandEditor");        
+        $("#first-pane").removeClass("expandEditor");
     }
 
     // Define public API


### PR DESCRIPTION
Since Jan 2018 Chrome has deprecated geolocation, microphone and camera
access from cross origin iframes
(https://sites.google.com/a/chromium.org/dev/Home/chromium-security/deprecating-permissions-in-cross-origin-iframes).
This prevents these features from being used in Thimble due to Thimble
using cross origin iframes.
Closes mozilla/thimble.mozilla.org#2614

@saxbophone and I tested locally on two different machines by setting up the full thimble stack. One machine was fine, the other worked but was a bit glitchy. Specifically, refreshing the preview window - we wondered whether this might have been a setup mistake on our part. Would be great if others could test this as well to make sure it resolves the issue.