### PR TITLE
Spelling: cachType => cacheType

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -132,7 +132,7 @@ if ('serviceWorker' in window.navigator) {
         "use strict";
         console.warn('[Bramble] Error during service worker registration:', e);
 
-        console.log('[Bramble] Falling back to cachType=blob due to failed service worker');
+        console.log('[Bramble] Falling back to cacheType=blob due to failed service worker');
         window.brambleCacheType = 'blob';
     });
 }


### PR DESCRIPTION
Fixes a spelling error in a console warning.  Couldn't just let it go. :grin:

Ran across this while trying to understand why IndexedDB issues are making [our Brackets/Bramble fork](https://github.com/code-dot-org/bramble) unusable to students in a number of schools.  It looks like some changes last summer, notably https://github.com/filerjs/filer/pull/370 and https://github.com/mozilla/thimble.mozilla.org/issues/2427 and this [fallback behavior](https://github.com/mozilla/brackets/pull/894/files#diff-1c90ff38a08209f9ebd4d05d1e43358eR132) when registering the service worker doesn't go as planned.  I'm not actually sure this is the root cause of _our_ issue though; still digging.